### PR TITLE
Update ci to include 6.7 with nsx-t23, remove 6.0, 6.5 and 6.5 nsxv

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,11 @@
 | Job | Status |
 | :--- | :--- |
 | Unit | [![ci.vcna.io](https://ci.vcna.io/api/v1/teams/vcpi/pipelines/vSphere-CPI/jobs/unit-test/badge)](https://ci.vcna.io/teams/vcpi/pipelines/vSphere-CPI?groups=Complete-View)|
-| Core Tests Lifecycle-6.0 | [![ci.vcna.io](https://ci.vcna.io/api/v1/teams/vcpi/pipelines/vSphere-CPI/jobs/lifecycle-6.0/badge)](https://ci.vcna.io/teams/vcpi/pipelines/vSphere-CPI?groups=Complete-View)|
-| Core Tests Lifecycle-6.5 | [![ci.vcna.io](https://ci.vcna.io/api/v1/teams/vcpi/pipelines/vSphere-CPI/jobs/lifecycle-6.5/badge)](https://ci.vcna.io/teams/vcpi/pipelines/vSphere-CPI?groups=Complete-View)|
-| Lifecycle-6.5 with NSXV | [![ci.vcna.io](https://ci.vcna.io/api/v1/teams/vcpi/pipelines/vSphere-CPI/jobs/lifecycle-6.5-NSXV/badge)](https://ci.vcna.io/teams/vcpi/pipelines/vSphere-CPI?groups=Complete-View)|
 | Lifecycle-6.0 with NSXV | [![ci.vcna.io](https://ci.vcna.io/api/v1/teams/vcpi/pipelines/vSphere-CPI/jobs/lifecycle-6.0-NSXV/badge)](https://ci.vcna.io/teams/vcpi/pipelines/vSphere-CPI?groups=Complete-View)|
 | Lifecycle-6.5 with NSXT-21 | [![ci.vcna.io](https://ci.vcna.io/api/v1/teams/vcpi/pipelines/vSphere-CPI/jobs/lifecycle-6.5-NSXT21/badge)](https://ci.vcna.io/teams/vcpi/pipelines/vSphere-CPI?groups=Complete-View)|
 | Lifecycle-6.5 with NSXT-22 | [![ci.vcna.io](https://ci.vcna.io/api/v1/teams/vcpi/pipelines/vSphere-CPI/jobs/lifecycle-6.5-NSXT22/badge)](https://ci.vcna.io/teams/vcpi/pipelines/vSphere-CPI?groups=Complete-View)|
 | Lifecycle-6.7 with NSXT-22 | [![ci.vcna.io](https://ci.vcna.io/api/v1/teams/vcpi/pipelines/vSphere-CPI/jobs/lifecycle-6.7-NSXT22/badge)](https://ci.vcna.io/teams/vcpi/pipelines/vSphere-CPI?groups=Complete-View)|
+| Lifecycle-6.7 with NSXT-23 | [![ci.vcna.io](https://ci.vcna.io/api/v1/teams/vcpi/pipelines/vSphere-CPI/jobs/lifecycle-6.7-NSXT23/badge)](https://ci.vcna.io/teams/vcpi/pipelines/vSphere-CPI?groups=Complete-View)|
 | BATS | [![ci.vcna.io](https://ci.vcna.io/api/v1/teams/vcpi/pipelines/vSphere-CPI/jobs/bats/badge)](https://ci.vcna.io/teams/vcpi/pipelines/vSphere-CPI?groups=Complete-View)|
 
 # BOSH vSphere CPI Release

--- a/ci/certifications/pipeline.yml
+++ b/ci/certifications/pipeline.yml
@@ -68,7 +68,7 @@ jobs:
         - get: source-ci
       - do:
         - put: environment
-          resource: pool-6.5
+          resource: pool-6.5-NSXT21
           params: {acquire: true}
         - task: extend-lease-6.5
           file: source-ci/ci/tasks/extend-lease.yml
@@ -77,14 +77,14 @@ jobs:
             DBCHOST: {{dbc_host}}
             DBC_SSH_KEY: {{dbc_key}}
           on_failure:
-            put: pool-6.5
+            put: pool-6.5-NSXT21
             params : {release: environment}
 
   - name: test-upgrade
     plan:
       - aggregate:
         - get: source-ci
-        - {get: environment,     trigger: true,  passed: [lock-test-upgrade], resource: pool-6.5 }
+        - {get: environment,     trigger: true,  passed: [lock-test-upgrade], resource: pool-6.5-NSXT21 }
         - {get: bosh-release,     trigger: false, passed: [lock-test-upgrade]}
         - {get: cpi-release,      trigger: false, passed: [lock-test-upgrade]}
         - {get: stemcell,         trigger: false, passed: [lock-test-upgrade], resource: ubuntu-stemcell}
@@ -123,7 +123,7 @@ jobs:
             new-director-state: director-state
         on_failure:
           aggregate:
-          - put: pool-6.5
+          - put: pool-6.5-NSXT21
             params : {remove: environment}
           - put: notify
             params:
@@ -136,9 +136,9 @@ jobs:
 
   - name: unlock-test-upgrade
     plan:
-      - {trigger: true, passed: [test-upgrade], get: pool-6.5}
-      - put: pool-6.5
-        params : {release: pool-6.5}
+      - {trigger: true, passed: [test-upgrade], get: pool-6.5-NSXT21}
+      - put: pool-6.5-NSXT21
+        params : {release: pool-6.5-NSXT21}
 
   - name: lock-test-stemcell-ipv4
     plan:
@@ -151,7 +151,7 @@ jobs:
         - get: source-ci
       - do:
         - put: environment
-          resource: pool-6.5
+          resource: pool-6.5-NSXT21
           params: {acquire: true}
         - task: extend-lease-6.5
           file: source-ci/ci/tasks/extend-lease.yml
@@ -160,7 +160,7 @@ jobs:
             DBCHOST: {{dbc_host}}
             DBC_SSH_KEY: {{dbc_key}}
           on_failure:
-            put: pool-6.5
+            put: pool-6.5-NSXT21
             params : {release: environment}
 
   - name: test-stemcell-ipv4
@@ -172,7 +172,7 @@ jobs:
         - {get: cpi-release,     trigger: false, passed: [lock-test-stemcell-ipv4]}
         - {get: stemcell,        trigger: false, passed: [lock-test-stemcell-ipv4], resource: ubuntu-stemcell}
         - {get: certification,   trigger: false}
-        - {get: environment,     trigger: true,  passed: [lock-test-stemcell-ipv4], resource: pool-6.5 }
+        - {get: environment,     trigger: true,  passed: [lock-test-stemcell-ipv4], resource: pool-6.5-NSXT21 }
         - {get: bosh-cli,        trigger: false}
         - {get: bats,            trigger: false}
         - {get: bosh-deployment, trigger: false}
@@ -190,7 +190,7 @@ jobs:
           - <<: *test-stemcell-ipv4
           on_failure:
             aggregate:
-            - put: pool-6.5
+            - put: pool-6.5-NSXT21
               params : {remove: environment}
             - put: notify
               params:
@@ -203,9 +203,9 @@ jobs:
 
   - name: unlock-test-stemcell-ipv4
     plan:
-      - {trigger: true, passed: [test-stemcell-ipv4], get: pool-6.5}
-      - put: pool-6.5
-        params : {release: pool-6.5}
+      - {trigger: true, passed: [test-stemcell-ipv4], get: pool-6.5-NSXT21}
+      - put: pool-6.5-NSXT21
+        params : {release: pool-6.5-NSXT21}
 
   - name: lock-test-stemcell-ipv6
     plan:
@@ -218,7 +218,7 @@ jobs:
         - get: source-ci
       - do:
         - put: environment
-          resource: pool-6.5
+          resource: pool-6.5-NSXT21
           params: {acquire: true}
         - task: extend-lease-6.5
           file: source-ci/ci/tasks/extend-lease.yml
@@ -227,7 +227,7 @@ jobs:
             DBCHOST: {{dbc_host}}
             DBC_SSH_KEY: {{dbc_key}}
           on_failure:
-            put: pool-6.5
+            put: pool-6.5-NSXT21
             params : {release: environment}
         attempts: 4
 
@@ -238,7 +238,7 @@ jobs:
         - {get: bosh-release,    trigger: false, passed: [lock-test-stemcell-ipv6]}
         - {get: cpi-release,     trigger: false, passed: [lock-test-stemcell-ipv6]}
         - {get: stemcell,        trigger: false, passed: [lock-test-stemcell-ipv6], resource: ubuntu-stemcell}
-        - {get: environment,     trigger: true,  passed: [lock-test-stemcell-ipv6], resource: pool-6.5 }
+        - {get: environment,     trigger: true,  passed: [lock-test-stemcell-ipv6], resource: pool-6.5-NSXT21 }
         - {get: certification,   trigger: false}
         - {get: bosh-cli,        trigger: false}
         - {get: bats,            trigger: false}
@@ -258,7 +258,7 @@ jobs:
         - <<: *test-stemcell-ipv6
         on_failure:
           aggregate:
-          - put: pool-6.5
+          - put: pool-6.5-NSXT21
             params : {remove: environment}
           - put: notify
             params:
@@ -271,9 +271,9 @@ jobs:
 
   - name: unlock-test-stemcell-ipv6
     plan:
-      - {trigger: true, passed: [test-stemcell-ipv6], get: pool-6.5}
-      - put: pool-6.5
-        params : {release: pool-6.5}
+      - {trigger: true, passed: [test-stemcell-ipv6], get: pool-6.5-NSXT21}
+      - put: pool-6.5-NSXT21
+        params : {release: pool-6.5-NSXT21}
 
   - name: lock-bats-centos
     plan:
@@ -286,7 +286,7 @@ jobs:
         - get: source-ci
       - do:
         - put: environment
-          resource: pool-6.5
+          resource: pool-6.5-NSXT21
           params: {acquire: true}
         - task: extend-lease-6.5
           file: source-ci/ci/tasks/extend-lease.yml
@@ -295,7 +295,7 @@ jobs:
             DBCHOST: {{dbc_host}}
             DBC_SSH_KEY: {{dbc_key}}
           on_failure:
-            put: pool-6.5
+            put: pool-6.5-NSXT21
             params : {release: environment}
         attempts: 4
 
@@ -304,7 +304,7 @@ jobs:
     plan:
       - aggregate:
         - get: source-ci
-        - {get: environment,     trigger: true,  passed: [lock-bats-centos], resource: pool-6.5 }
+        - {get: environment,     trigger: true,  passed: [lock-bats-centos], resource: pool-6.5-NSXT21 }
         - {get: certification,   trigger: false}
         - {get: bosh-cli,        trigger: false}
         - {get: bosh-release,    trigger: false, passed: [lock-bats-centos]}
@@ -321,7 +321,7 @@ jobs:
             STEMCELL_NAME: bosh-vsphere-esxi-centos-7-go_agent
         on_failure:
           aggregate:
-          - put: pool-6.5
+          - put: pool-6.5-NSXT21
             params : {remove: environment}
           - put: notify
             params:
@@ -334,9 +334,9 @@ jobs:
 
   - name: unlock-bats-centos
     plan:
-      - {trigger: true, passed: [bats-centos], get: pool-6.5}
-      - put: pool-6.5
-        params : {release: pool-6.5}
+      - {trigger: true, passed: [bats-centos], get: pool-6.5-NSXT21}
+      - put: pool-6.5-NSXT21
+        params : {release: pool-6.5-NSXT21}
 
   - name: lock-bats-ubuntu
     plan:
@@ -349,7 +349,7 @@ jobs:
         - get: source-ci
       - do:
         - put: environment
-          resource: pool-6.5
+          resource: pool-6.5-NSXT21
           params: {acquire: true}
         - task: extend-lease-6.5
           file: source-ci/ci/tasks/extend-lease.yml
@@ -358,7 +358,7 @@ jobs:
             DBCHOST: {{dbc_host}}
             DBC_SSH_KEY: {{dbc_key}}
           on_failure:
-            put: pool-6.5
+            put: pool-6.5-NSXT21
             params : {release: environment}
         attempts: 4
 
@@ -367,7 +367,7 @@ jobs:
     plan:
       - aggregate:
         - get: source-ci
-        - {get: environment,     trigger: true,  passed: [lock-bats-ubuntu], resource: pool-6.5 }
+        - {get: environment,     trigger: true,  passed: [lock-bats-ubuntu], resource: pool-6.5-NSXT21 }
         - {get: certification,   trigger: false}
         - {get: bosh-cli,        trigger: false}
         - {get: bosh-release,    trigger: false, passed: [lock-bats-ubuntu]}
@@ -384,7 +384,7 @@ jobs:
             STEMCELL_NAME: bosh-vsphere-esxi-ubuntu-trusty-go_agent
         on_failure:
           aggregate:
-          - put: pool-6.5
+          - put: pool-6.5-NSXT21
             params : {remove: environment}
           - put: notify
             params:
@@ -397,9 +397,9 @@ jobs:
 
   - name: unlock-bats-ubuntu
     plan:
-      - {trigger: true, passed: [bats-ubuntu], get: pool-6.5}
-      - put: pool-6.5
-        params : {release: pool-6.5}
+      - {trigger: true, passed: [bats-ubuntu], get: pool-6.5-NSXT21}
+      - put: pool-6.5-NSXT21
+        params : {release: pool-6.5-NSXT21}
 
   - name: certify-centos
     plan:
@@ -496,12 +496,12 @@ resources:
       regexp:       bosh-cli-([0-9.]+)-linux-amd64
       bucket:       bosh-cli-artifacts
       region_name:  us-east-1
-  - name: pool-6.5
+  - name: pool-6.5-NSXT21
     type: pool
     source:
       uri:          git@github.com:ktchen14/vcpi-pool.git
       branch:       master
-      pool:         v6.5
+      pool:         v6.5-nsxt21
       private_key:  {{vcpi-pool_deployment_key}}
   - name: source-ci
     type: git

--- a/ci/config.rb
+++ b/ci/config.rb
@@ -1,38 +1,8 @@
-$pipeline.pool('6.0') do |pool|
-  pool.params = {
-    RSPEC_FLAGS: [
-      '--tag ~nsx_vsphere',
-      '--tag ~nsxt_2',
-      '--tag ~nsxt_21',
-    ].join(' '),
-    NSXT_SKIP_SSL_VERIFY: "true"
-  }
-end
-
 $pipeline.pool('6.0-NSXV') do |pool|
   pool.params = {
     RSPEC_FLAGS: [
-      '--tag nsx_vsphere',
-    ].join(' '),
-    NSXT_SKIP_SSL_VERIFY: "true"
-  }
-end
-
-$pipeline.pool('6.5') do |pool|
-  pool.params = {
-    RSPEC_FLAGS: [
-      '--tag ~disk_migration',
-      '--tag ~nsx_vsphere',
+      '--tag ~nsxt_2',
       '--tag ~nsxt_21',
-    ].join(' '),
-    NSXT_SKIP_SSL_VERIFY: "true"
-  }
-end
-
-$pipeline.pool('6.5-NSXV') do |pool|
-  pool.params = {
-    RSPEC_FLAGS: [
-      '--tag nsx_vsphere',
     ].join(' '),
     NSXT_SKIP_SSL_VERIFY: "true"
   }
@@ -41,7 +11,8 @@ end
 $pipeline.pool('6.5-NSXT21') do |pool|
   pool.params = {
     RSPEC_FLAGS: [
-      '--tag nsxt_21',
+      '--tag ~disk_migration',
+      '--tag ~nsx_vsphere',
     ].join(' '),
     NSXT_SKIP_SSL_VERIFY: "true"
   }
@@ -50,8 +21,7 @@ end
 $pipeline.pool('6.5-NSXT22') do |pool|
   pool.params = {
     RSPEC_FLAGS: [
-      '--tag nsx_transformers',
-      '--tag nsxt_21'
+      '--tag nsx_transformers'
     ].join(' '),
     NSXT_SKIP_SSL_VERIFY: "true"
   }
@@ -60,9 +30,17 @@ end
 $pipeline.pool('6.7-NSXT22') do |pool|
   pool.params = {
     RSPEC_FLAGS: [
-      '--tag ~disk_migration',
       '--tag ~nsx_vsphere',
       '--tag ~host_maintenance',
+    ].join(' '),
+    NSXT_SKIP_SSL_VERIFY: "true"
+  }
+end
+
+$pipeline.pool('6.7-NSXT23') do |pool|
+  pool.params = {
+    RSPEC_FLAGS: [
+      '--tag nsx_transformers'
     ].join(' '),
     NSXT_SKIP_SSL_VERIFY: "true"
   }

--- a/ci/pipeline/main.yml.erb
+++ b/ci/pipeline/main.yml.erb
@@ -22,13 +22,11 @@ jobs:
       - get: bosh-cpi-src
         trigger: true
         passed:
-        - lifecycle-6.0
         - lifecycle-6.0-NSXV
-        - lifecycle-6.5
-        - lifecycle-6.5-NSXV
         - lifecycle-6.5-NSXT21
         - lifecycle-6.5-NSXT22
         - lifecycle-6.7-NSXT22
+        - lifecycle-6.7-NSXT23
       - get: version-semver
         trigger: false
         params: { bump: patch }
@@ -52,7 +50,7 @@ jobs:
           passed: [build-candidate]
       - do:
         - put: environment
-          resource: pool-6.5
+          resource: pool-6.5-NSXT21
           params: {acquire: true}
         - task: extend-lease-6.5
           file: source-ci/ci/tasks/extend-lease.yml
@@ -61,7 +59,7 @@ jobs:
             DBCHOST: {{dbc_host}}
             DBC_SSH_KEY: {{dbc_key}}
           on_failure:
-            put: pool-6.5
+            put: pool-6.5-NSXT21
             params : {release: environment}
         attempts: 4
 
@@ -71,7 +69,7 @@ jobs:
       - aggregate:
         - get: source-ci
         - {get: cpi-release,              trigger: false, resource: bosh-cpi-artifacts, passed: [lock-bats]}
-        - {get: environment,              trigger: true,  passed: [lock-bats], resource: pool-6.5 }
+        - {get: environment,              trigger: true,  passed: [lock-bats], resource: pool-6.5-NSXT21}
         - {get: bosh-release,             trigger: false, resource: old-bosh-release}
         - {get: stemcell,                 trigger: false, resource: old-stemcell}
         - {get: certification,            trigger: false}
@@ -101,7 +99,7 @@ jobs:
             STEMCELL_NAME:      bosh-vsphere-esxi-ubuntu-trusty-go_agent
         on_failure:
           aggregate:
-          - put: pool-6.5
+          - put: pool-6.5-NSXT21
             params : {remove: environment}
           - put: notify
             params:
@@ -120,9 +118,9 @@ jobs:
 
   - name: unlock-bats
     plan:
-      - {trigger: true, passed: [bats], get: pool-6.5}
-      - put: pool-6.5
-        params : {release: pool-6.5}
+      - {trigger: true, passed: [bats], get: pool-6.5-NSXT21}
+      - put: pool-6.5-NSXT21
+        params : {release: pool-6.5-NSXT21}
 
 
   - name: lock-distribution-test
@@ -136,7 +134,7 @@ jobs:
           passed: [bats]
       - do:
         - put: environment
-          resource: pool-6.5
+          resource: pool-6.5-NSXT21
           params: {acquire: true}
         - task: extend-lease-6.5
           file: source-ci/ci/tasks/extend-lease.yml
@@ -145,7 +143,7 @@ jobs:
             DBCHOST: {{dbc_host}}
             DBC_SSH_KEY: {{dbc_key}}
           on_failure:
-            put: pool-6.5
+            put: pool-6.5-NSXT21
             params : {release: environment}
         attempts: 4
 
@@ -155,7 +153,7 @@ jobs:
       - aggregate:
         - get: source-ci
         - {get: cpi-release,              trigger: false, resource: bosh-cpi-artifacts, passed: [lock-distribution-test]}
-        - {get: environment,              trigger: true,  passed: [lock-distribution-test], resource: pool-6.5 }
+        - {get: environment,              trigger: true,  passed: [lock-distribution-test], resource: pool-6.5-NSXT21}
         - {get: bosh-release,             trigger: false, resource: old-bosh-release}
         - {get: stemcell,                 trigger: false, resource: old-stemcell}
         - {get: certification,            trigger: false}
@@ -178,7 +176,7 @@ jobs:
           file: source-ci/ci/tasks/run-distribution-test.yml
         on_failure:
           aggregate:
-          - put: pool-6.5
+          - put: pool-6.5-NSXT21
             params : {remove: environment}
           - put: notify
             params:
@@ -197,9 +195,9 @@ jobs:
 
   - name: unlock-distribution-test
     plan:
-      - {trigger: true, passed: [distribution-test], get: pool-6.5}
-      - put: pool-6.5
-        params : {release: pool-6.5}
+      - {trigger: true, passed: [distribution-test], get: pool-6.5-NSXT21}
+      - put: pool-6.5-NSXT21
+        params : {release: pool-6.5-NSXT21}
 
   - name: delivery
     plan:
@@ -207,12 +205,11 @@ jobs:
       - get: bosh-cpi-src
         trigger: ((trigger_delivery_job))
         passed:
-        - lifecycle-6.0
         - lifecycle-6.0-NSXV
-        - lifecycle-6.5
-        - lifecycle-6.5-NSXV
         - lifecycle-6.5-NSXT21
         - lifecycle-6.5-NSXT22
+        - lifecycle-6.7-NSXT22
+        - lifecycle-6.7-NSXT23
         - bats
     - put: tracker-output
       params: { repos: [bosh-cpi-src] }
@@ -267,13 +264,6 @@ resources:
     type: slack-notification
     source:
       url: {{slack_webhook}}
-  - name: pool-6.5-NSXV
-    type: pool
-    source:
-      uri:          git@github.com:ktchen14/vcpi-pool.git
-      branch:       master
-      pool:         v6.5-nsxv
-      private_key:  {{vcpi-pool_deployment_key}}
   - name: pool-6.5-NSXT21
     type: pool
     source:
@@ -295,26 +285,19 @@ resources:
       branch:       master
       pool:         v6.0-nsxv
       private_key:  {{vcpi-pool_deployment_key}}
-  - name: pool-6.5
-    type: pool
-    source:
-      uri:          git@github.com:ktchen14/vcpi-pool.git
-      branch:       master
-      pool:         v6.5
-      private_key:  {{vcpi-pool_deployment_key}}
-  - name: pool-6.0
-    type: pool
-    source:
-      uri:          git@github.com:ktchen14/vcpi-pool.git
-      branch:       master
-      pool:         v6.0
-      private_key:  {{vcpi-pool_deployment_key}}
   - name: pool-6.7-NSXT22
     type: pool
     source:
       uri:          git@github.com:ktchen14/vcpi-pool.git
       branch:       master
       pool:         v6.7-nsxt22
+      private_key:  {{vcpi-pool_deployment_key}}
+  - name: pool-6.7-NSXT23
+    type: pool
+    source:
+      uri:          git@github.com:ktchen14/vcpi-pool.git
+      branch:       master
+      pool:         v6.7-nsxt23
       private_key:  {{vcpi-pool_deployment_key}}
   - name: bosh-cpi-artifacts
     type: s3
@@ -404,20 +387,14 @@ groups:
   - bats
   - lock-bats
   - unlock-bats
-  - lock-6.5
-  - lifecycle-6.5
-  - unlock-6.5
+  - lock-6.7-NSXT23
+  - lifecycle-6.7-NSXT23
+  - unlock-6.7-NSXT23
   - lock-6.7-NSXT22
   - lifecycle-6.7-NSXT22
   - unlock-6.7-NSXT22
-  - lifecycle-6.0
-  - lock-6.0
-  - unlock-6.0
   - inspect-candidate
   - promote-candidate
-  - lock-6.5-NSXV
-  - lifecycle-6.5-NSXV
-  - unlock-6.5-NSXV
   - lock-6.5-NSXT21
   - lifecycle-6.5-NSXT21
   - unlock-6.5-NSXT21
@@ -434,10 +411,8 @@ groups:
 
 - name: Delivery
   jobs:
-  - lifecycle-6.5
-  - lifecycle-6.0
+  - lifecycle-6.7-NSXT23
   - lifecycle-6.7-NSXT22
-  - lifecycle-6.5-NSXV
   - lifecycle-6.5-NSXT21
   - lifecycle-6.5-NSXT22
   - lifecycle-6.0-NSXV
@@ -454,12 +429,6 @@ groups:
 - name: v6.5
   jobs:
   - unit-test
-  - lock-6.5
-  - lifecycle-6.5
-  - unlock-6.5
-  - lock-6.5-NSXV
-  - lifecycle-6.5-NSXV
-  - unlock-6.5-NSXV
   - lock-6.5-NSXT21
   - lifecycle-6.5-NSXT21
   - unlock-6.5-NSXT21
@@ -470,16 +439,16 @@ groups:
 - name: v6.0
   jobs:
   - unit-test
-  - lifecycle-6.0
-  - lock-6.0
-  - unlock-6.0
   - lifecycle-6.0-NSXV
   - lock-6.0-NSXV
   - unlock-6.0-NSXV
 
-- name: v6.7-NSXT22
+- name: v6.7
   jobs:
   - unit-test
   - lifecycle-6.7-NSXT22
   - lock-6.7-NSXT22
   - unlock-6.7-NSXT22
+  - lifecycle-6.7-NSXT23
+  - lock-6.7-NSXT23
+  - unlock-6.7-NSXT23


### PR DESCRIPTION
# Description

Add v6.7 with nsx-t 2.3 to CI pipeline. Remove 6.0, 6.5 and 6.5-nsxv tests. Use 6.0 nsxv to test everything for 6.0

## Impacted Areas in Application
List general components of the application that this PR will affect:

## Type of change

Please delete options that are not relevant.

- updates CI

## How Has This Been Tested?

- Tested 6.7 nsx-t 2.3 in a separate pipeline
