### PR TITLE
Add IPv6 BOSH IP to blobstore cert

### DIFF
--- a/ci/certifications/pipeline.yml
+++ b/ci/certifications/pipeline.yml
@@ -25,6 +25,7 @@ shared:
         -o certification/shared/assets/ops/remove-hm.yml
         -o bosh-deployment/misc/ipv6/bosh.yml
         -o certification/vsphere/assets/ipv6-director.yml
+        -o source-ci/ci/shared/ops/blobstore_server_tls_ipv6.yml
         -o bosh-deployment/misc/second-network.yml
         -o bosh-deployment/vsphere/second-network.yml
   - &deploy-director

--- a/ci/shared/ops/blobstore_server_tls_ipv6.yml
+++ b/ci/shared/ops/blobstore_server_tls_ipv6.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /variables/name=blobstore_server_tls/options/alternative_names/-
+  value: "((second_internal_ip))"


### PR DESCRIPTION
# Description

Final change to allow job `test-stemcell-ipv6` to run. 

## Impacted Areas in Application
None. Verifies IPv6 compatibility

## Type of change

- [x] CI Fix

## How Has This Been Tested?

https://ci.vcna.io/teams/vcpi/pipelines/vcpi-ta-Certify-ip6-certification/jobs/test-stemcell-ipv6/builds/4

**Test Configuration**:
Using ipv6 testbed.

# Checklist:

- [NA] My code follows the standard ruby style guide
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [NA] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
