### PR TITLE
Expand reserved range for BOSH Network to include 192.168.111.155

### DIFF
--- a/ci/shared/distribution-test-cloud-config.yml
+++ b/ci/shared/distribution-test-cloud-config.yml
@@ -31,7 +31,7 @@ networks:
     - 192.168.111.1
     gateway: 192.168.111.1
     range: 192.168.111.0/24
-    reserved: [192.168.111.0-192.168.111.154]
+    reserved: [192.168.111.0-192.168.111.155]
   type: manual
 vm_types:
 - cloud_properties:

--- a/ci/tasks/prepare-director.sh
+++ b/ci/tasks/prepare-director.sh
@@ -50,7 +50,7 @@ bosh int \
   -v internal_cidr=192.168.111.0/24 \
   -v internal_gw=192.168.111.1 \
   -v internal_ip=192.168.111.152 \
-  -v reserved_range=192.168.111.2-192.168.111.154 \
+  -v reserved_range=192.168.111.2-192.168.111.155 \
   -v network_name="$BOSH_VSPHERE_VLAN" \
   -v vcenter_dc="$BOSH_VSPHERE_CPI_DATACENTER" \
   -v vcenter_ds="$unambiguous_ds" \

--- a/ci/tasks/run-bats.sh
+++ b/ci/tasks/run-bats.sh
@@ -17,7 +17,7 @@ bosh int source-ci/ci/shared/bats-spec.yml \
   -v network1-staticIP-1=192.168.111.155 \
   -v network1-vCenterCIDR=192.168.111.0/24 \
   -v network1-staticRange=[192.168.111.155-192.168.111.163] \
-  -v network1-reservedRange="['192.168.111.0-192.168.111.154' , '192.168.111.164-192.168.111.174']" \
+  -v network1-reservedRange="['192.168.111.0-192.168.111.155' , '192.168.111.164-192.168.111.174']" \
   -v network1-vCenterGateway=192.168.111.1 \
   -v network1-vCenterVLAN="VM Network" \
   -v network2-staticIP-1=192.168.111.164 \

--- a/ci/tasks/update-cloud-config.sh
+++ b/ci/tasks/update-cloud-config.sh
@@ -15,7 +15,7 @@ bosh -n update-cloud-config bosh-deployment/vsphere/cloud-config.yml \
     -v internal_cidr=192.168.111.0/24 \
     -v internal_gw=192.168.111.1 \
     -v internal_ip=192.168.111.152 \
-    -v reserved_range=192.168.111.2-192.168.111.154 \
+    -v reserved_range=192.168.111.2-192.168.111.155 \
     -v network_name="$BOSH_VSPHERE_VLAN" \
     -v vcenter_dc="$BOSH_VSPHERE_CPI_DATACENTER" \
     -v vcenter_ds="$unambiguous_ds" \


### PR DESCRIPTION
# Description

Expand the reserved range in BOSH Network for the CI tests.

## Impacted Areas in Application
CI

## Type of change

- [x] Updates CI Config

## How Has This Been Tested?

NA

# Checklist:

- [NA ] My code follows the standard ruby style guide
- [x] I have performed a self-review of my own code
- [NA] I have commented my code, particularly in hard-to-understand areas
- [NA] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
