### PR TITLE
Enable host group specification in a Cluster

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -662,6 +662,7 @@ module VSphereCloud
         relocation_spec.disk_move_type = Vim::Vm::RelocateSpec::DiskMoveOptions::CREATE_NEW_CHILD_DISK_BACKING
       end
       relocation_spec.pool = resource_pool
+      relocation_spec.host = options[:host] unless options[:host].nil?
 
       clone_spec = Vim::Vm::CloneSpec.new
       clone_spec.config = options[:config] if options[:config]

--- a/src/vsphere_cpi/lib/cloud/vsphere/cluster_config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cluster_config.rb
@@ -8,8 +8,8 @@ module VSphereCloud
       @config = config_hash
     end
 
-    def resource_pool
-      @config['resource_pool']
-    end
+    def host_group; @config['host_group']; end
+
+    def resource_pool; @config['resource_pool']; end
   end
 end

--- a/src/vsphere_cpi/lib/cloud/vsphere/drs_rules/vm_group.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/drs_rules/vm_group.rb
@@ -17,7 +17,7 @@ module VSphereCloud
     # @param [Vim::VirtualMachine] vm
     # @params [String] vm_group_name
     def add_vm_to_vm_group(vm, vm_group_name)
-      DrsLock.new(@vm_attribute_manager, DRS_LOCK_VMGROUP ).with_drs_lock do
+      DrsLock.new(@vm_attribute_manager, DRS_LOCK_VMGROUP).with_drs_lock do
         vm_group = find_vm_group(vm_group_name)
         logger.debug("VmGroup: #{vm_group_name} already exists") unless vm_group.nil?
 
@@ -43,7 +43,7 @@ module VSphereCloud
     def delete_vm_groups(vm_group_names)
       return if vm_group_names.empty?
       vm_attribute_manager = VMAttributeManager.new(@client.service_content.custom_fields_manager)
-      DrsLock.new(vm_attribute_manager, DRS_LOCK_VMGROUP ).with_drs_lock do
+      DrsLock.new(vm_attribute_manager, DRS_LOCK_VMGROUP).with_drs_lock do
         empty_vm_groups = @cluster.configuration_ex.group.select do |group|
           group.is_a?(VimSdk::Vim::Cluster::VmGroup) && vm_group_names.include?(group.name) && group.vm.empty?
         end
@@ -59,8 +59,22 @@ module VSphereCloud
           group_spec.remove_key = vm_group.name
           group_spec
         end
+
+        # If these vm_groups are getting deleted. Also delete all the
+        # vm-host group rules associated with it.
+        #
+        # @TODO : CAVEAT: if anyone creates a rule outside of CPI using these
+        # vm_groups, it will be deleted too. To narrow
+        # the scope of this caveat, CPI will only delete the
+        # vm-host-group-affinity rule type. This is because, currently it only
+        # creates vm-host-affinity rule using vm groups.
+        rules_spec = get_delete_rule_spec(empty_vm_groups) unless empty_vm_groups.nil?
         config_spec = VimSdk::Vim::Cluster::ConfigSpecEx.new
         config_spec.group_spec = group_specs
+        unless rules_spec&.empty?
+          logger.debug("Deleting #{rules_spec.count} vm host affinity rules")
+          config_spec.rules_spec = rules_spec
+        end
         @client.wait_for_task do
           @cluster.reconfigure_ex(config_spec, true)
         end
@@ -68,6 +82,29 @@ module VSphereCloud
     end
 
     private
+    def get_delete_rule_spec(empty_vm_groups)
+      # returning empty array for consistent return type.
+      if @cluster.configuration_ex.rule.nil?
+        return []
+      end
+      rules_spec= empty_vm_groups.each_with_object([]) do |vm_group, rules_spec|
+        # Filter rules for deletion
+        rule_keys = @cluster.configuration_ex.rule.select do |rule_info|
+          rule_info.is_a?(VimSdk::Vim::Cluster::VmHostRuleInfo) && \
+              rule_info.vm_group_name == vm_group.name
+        end.map(&:key)
+
+        # Generate Rule Spec
+        rule_keys.each do |rkey|
+          rule_spec = VimSdk::Vim::Cluster::RuleSpec.new
+          rule_spec.operation = VimSdk::Vim::Option::ArrayUpdateSpec::Operation::REMOVE
+          rule_spec.remove_key = rkey
+          rules_spec << rule_spec
+        end
+      end
+      rules_spec
+    end
+
 
     def find_vm_group(vm_group_name)
       @cluster.configuration_ex.group.find do |group|

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/datastore.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/datastore.rb
@@ -92,7 +92,7 @@ module VSphereCloud
       def accessible_from?(cluster)
         @mob.host.any? do |host_mount|
           next if host_mount.key.runtime.in_maintenance_mode
-          cluster.mob.host.include?(host_mount.key)
+          cluster.host.include?(host_mount.key)
         end
       end
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_placement_selection_pipeline.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_placement_selection_pipeline.rb
@@ -43,7 +43,7 @@ module VSphereCloud
     end
 
     def inspect_before
-      "VM Placement Cluster : #{cluster.name} hosts: #{hosts} datastores: #{datastores}"
+      "VM Placement Cluster: #{cluster.name} hosts: #{hosts} datastores: #{datastores}"
     end
 
     def inspect

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_type.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_type.rb
@@ -13,7 +13,7 @@ module VSphereCloud
     end
 
     %w[cpu ram disk cpu_hot_add_enabled memory_hot_add_enabled nsx vmx_options
-       nsxt nested_hardware_virtualization upgrade_hw_version datacenters vm_group ].each do |name|
+       nsxt nested_hardware_virtualization upgrade_hw_version datacenters vm_group].each do |name|
       define_method(name) { @cloud_properties[name] }
     end
 

--- a/src/vsphere_cpi/spec/integration/vm_host_rule_spec.rb
+++ b/src/vsphere_cpi/spec/integration/vm_host_rule_spec.rb
@@ -1,0 +1,348 @@
+require 'integration/spec_helper'
+
+describe 'Host Groups in Cluster and VM Host Rules' do
+  context 'when host groups are defined in AZ' do
+    before(:all) do
+      @datacenter_name = fetch_and_verify_datacenter('BOSH_VSPHERE_CPI_DATACENTER')
+      @cluster_name = fetch_and_verify_cluster('BOSH_VSPHERE_CPI_CLUSTER')
+      @second_cluster_name = fetch_and_verify_cluster('BOSH_VSPHERE_CPI_SECOND_CLUSTER')
+      @datastore_shared_pattern = fetch_property('BOSH_VSPHERE_CPI_SHARED_DATASTORE')
+      @first_cluster_datastore=fetch_property('BOSH_VSPHERE_CPI_DATASTORE_PATTERN')
+      @first_host_group = fetch_property('BOSH_VSPHERE_CPI_FIRST_CLUSTER_FIRST_HOST_GROUP')
+      @second_host_group = fetch_property('BOSH_VSPHERE_CPI_FIRST_CLUSTER_SECOND_HOST_GROUP')
+      @third_host_group = fetch_property('BOSH_VSPHERE_CPI_SECOND_CLUSTER_FIRST_HOST_GROUP')
+      @second_cluster_resource_pool_name = fetch_and_verify_resource_pool('BOSH_VSPHERE_CPI_SECOND_CLUSTER_RESOURCE_POOL', @second_cluster_name)
+    end
+
+    let(:options) do
+      cpi_options(
+        datacenters: [{
+          clusters: [
+            {
+              @cluster_name => {
+                host_group:  @first_host_group,
+              }
+            }
+          ]
+        }]
+      )
+    end
+    let(:cpi) do
+      VSphereCloud::Cloud.new(options)
+    end
+    let(:vm_type) do
+      {
+        'ram' => 512,
+        'disk' => 2048,
+        'cpu' => 1,
+      }
+    end
+    let(:cluster_mob) do
+      cpi.client.cloud_searcher.get_managed_object(
+        VimSdk::Vim::ClusterComputeResource, name: @cluster_name)
+    end
+    let(:second_cluster_mob) do
+      cpi.client.cloud_searcher.get_managed_object(
+        VimSdk::Vim::ClusterComputeResource, name: @second_cluster_name)
+    end
+    let(:first_host_group_mob) { find_host_group_mob(@first_host_group) }
+    let(:second_host_group_mob) { find_host_group_mob(@second_host_group) }
+    let(:third_host_group_mob) { find_host_group_mob(@third_host_group, second_cluster_mob) }
+    let(:hosts_in_first_host_group) { first_host_group_mob.host.map(&:name) }
+    let(:hosts_in_second_host_group) { second_host_group_mob.host.map(&:name) }
+    let(:hosts_in_third_host_group) { third_host_group_mob.host.map(&:name) }
+
+    context 'when there is only one vSphere cluster in an AZ' do
+      context 'and one host_group is specified in the cluster' do
+        it 'creates one VM on one of the hosts in the host groups' do
+          simple_vm_lifecycle(cpi, '', vm_type, get_network_spec) do |vm_id|
+            vm = cpi.vm_provider.find(vm_id)
+            expect(hosts_in_first_host_group).to include(vm.mob.runtime.host.name)
+            expect(vm.cluster).to eq(@cluster_name)
+          end
+          expect(get_count_vm_host_affinity_rules(cluster_mob)).to eq(0)
+        end
+        it 'creates multiple VMs (3) one after another on one of the hosts in the host groups' do
+          vm_list = []
+          begin
+            3.times do
+              vm_id = cpi.create_vm(
+                'agent-007',
+                @stemcell_id,
+                vm_type,
+                get_network_spec,
+                [],
+                {}
+              )
+              expect(vm_id).to_not be_nil
+              vm_list << vm_id
+              vm = cpi.vm_provider.find(vm_id)
+              expect(vm).to_not be_nil
+              expect(hosts_in_first_host_group).to include(vm.mob.runtime.host.name)
+              expect(vm.cluster).to eq(@cluster_name)
+            end
+          ensure
+            vm_list.each do |vm_id|
+              delete_vm(cpi, vm_id)
+            end
+            expect(get_count_vm_host_affinity_rules(cluster_mob)).to eq(0)
+          end
+        end
+        it 'creates and deletes multiple VMs (5) in parallel' do
+          thread_list = []
+          5.times do
+            thread_list << Thread.new do
+              simple_vm_lifecycle(cpi, '', vm_type, get_network_spec) do |vm_id|
+                vm = cpi.vm_provider.find(vm_id)
+                expect(hosts_in_first_host_group).to include(vm.mob.runtime.host.name)
+                expect(vm.cluster).to eq(@cluster_name)
+              end
+            end
+          end
+          thread_list.each {|thread| thread.join}
+          expect(get_count_vm_host_affinity_rules(cluster_mob)).to eq(0)
+        end
+        context 'and both host in the host group cannot access ephemeral datastore' do
+          let(:options) do
+            cpi_options(
+              datacenters: [{
+                'datastore_pattern' => 'isc-cl2-ds-0'
+              }]
+            )
+          end
+          let(:cpi) do
+            VSphereCloud::Cloud.new(options)
+          end
+          it 'raises error for no placement found' do
+            expect do
+              cpi.create_vm(
+                'agent-007',
+                @stemcell_id,
+                vm_type,
+                get_network_spec,
+                [],
+                {}
+              )
+            end.to raise_error(/No valid placement found/)
+            expect(get_count_vm_host_affinity_rules(cluster_mob)).to eq(0)
+          end
+        end
+      end
+      context 'and multiple host groups are specified in same vSphere cluster' do
+        let(:cpi) do
+          VSphereCloud::Cloud.new(cpi_options)
+        end
+        let(:vm_type) do
+          {
+            'ram' => 512,
+            'disk' => 2048,
+            'cpu' => 1,
+            'datacenters' => [{
+              'name' => @datacenter_name,
+              'clusters' => [
+                {
+                  @cluster_name => {
+                    'host_group' =>  @second_host_group,
+                  },
+                },
+                {
+                  @cluster_name => {
+                    'host_group' =>  @first_host_group,
+                  }
+                },
+              ]
+            }]
+          }
+        end
+        it 'creates VM and attach vm group host affinity rule' do
+          simple_vm_lifecycle(cpi, '', vm_type, get_network_spec) do |vm_id|
+            vm = cpi.vm_provider.find(vm_id)
+            expect(vm.cluster).to eq(@cluster_name)
+            # We expect VM to be created on first host group
+            # because first host group has two hosts and more memory.
+            expect(hosts_in_first_host_group).to include(vm.mob.runtime.host.name)
+          end
+          expect(get_count_vm_host_affinity_rules(cluster_mob)).to eq(0)
+        end
+      end
+    end
+
+    context 'when there are  multiple vSphere cluster in an AZ' do
+      context 'and one host_group is specified in each cluster' do
+        let(:options) do
+          cpi_options(
+            datacenters: [{
+              datastore_pattern: @datastore_shared_pattern,
+              persistent_datastore_pattern: @datastore_shared_pattern,
+              clusters: [
+                { @cluster_name => { host_group: @first_host_group } },
+                { @second_cluster_name => { host_group: @third_host_group } },
+              ]
+            }]
+          )
+        end
+        let(:cpi) do
+          VSphereCloud::Cloud.new(options)
+        end
+        it 'creates one VM on one of the hosts in the host groups of any cluster' do
+          simple_vm_lifecycle(cpi, '', vm_type, get_network_spec) do |vm_id|
+            vm = cpi.vm_provider.find(vm_id)
+            expected_host_group_mob = if vm.cluster == @cluster_name
+              first_host_group_mob
+            else
+              third_host_group_mob
+            end
+            vm_host = vm.mob.runtime.host.name
+            expect(expected_host_group_mob.host.map(&:name)).to include(vm_host)
+          end
+          expect(get_count_vm_host_affinity_rules(cluster_mob) +
+            get_count_vm_host_affinity_rules(second_cluster_mob)).to eq(0)
+        end
+        it 'creates multiple VMs (3) one after another on one of the hosts in the host groups' do
+          vm_list = []
+          begin
+            3.times do
+              vm_id = cpi.create_vm(
+                'agent-007',
+                @stemcell_id,
+                vm_type,
+                get_network_spec,
+                [],
+                {}
+              )
+              expect(vm_id).to_not be_nil
+              vm_list << vm_id
+              vm = cpi.vm_provider.find(vm_id)
+              expect(vm).to_not be_nil
+              expected_host_group_mob = if vm.cluster == @cluster_name
+                first_host_group_mob
+              else
+                third_host_group_mob
+              end
+              vm_host = vm.mob.runtime.host.name
+              expect(expected_host_group_mob.host.map(&:name)).to include(vm_host)
+            end
+          ensure
+            vm_list.each do |vm_id|
+              delete_vm(cpi, vm_id)
+            end
+            expect(get_count_vm_host_affinity_rules(cluster_mob) +
+              get_count_vm_host_affinity_rules(second_cluster_mob)).to eq(0)
+          end
+        end
+        it 'creates and deletes multiple VMs (5) in parallel' do
+          thread_list = []
+          5.times do
+            thread_list << Thread.new do
+              simple_vm_lifecycle(cpi, '', vm_type, get_network_spec) do |vm_id|
+                vm = cpi.vm_provider.find(vm_id)
+                expected_host_group_mob = if vm.cluster == @cluster_name
+                  first_host_group_mob
+                else
+                  third_host_group_mob
+                end
+                vm_host = vm.mob.runtime.host.name
+                expect(expected_host_group_mob.host.map(&:name)).to include(vm_host)
+              end
+            end
+          end
+          thread_list.each {|thread| thread.join}
+          expect(get_count_vm_host_affinity_rules(cluster_mob)).to eq(0)
+        end
+        context 'and all hosts in first cluster host group are in maintenance mode' do
+          before do
+            turn_maintenance_on_for_hosts(cpi, first_host_group_mob.host)
+          end
+          after do
+            turn_maintenance_off_for_hosts(cpi, first_host_group_mob.host)
+          end
+          it 'creates one VM on one of the hosts in the host groups of second cluster' do
+            simple_vm_lifecycle(cpi, '', vm_type, get_network_spec) do |vm_id|
+              vm = cpi.vm_provider.find(vm_id)
+              vm_host = vm.mob.runtime.host.name
+              expect(third_host_group_mob.host.map(&:name)).to include(vm_host)
+              expect(vm.cluster).to eq(@second_cluster_name)
+            end
+            expect(get_count_vm_host_affinity_rules(cluster_mob) +
+              get_count_vm_host_affinity_rules(second_cluster_mob)).to eq(0)
+          end
+          it 'creates and deletes multiple VMs (5) in parallel' do
+            thread_list = []
+            5.times do
+              thread_list << Thread.new do
+                simple_vm_lifecycle(cpi, '', vm_type, get_network_spec) do |vm_id|
+                  vm = cpi.vm_provider.find(vm_id)
+                  vm_host = vm.mob.runtime.host.name
+                  expect(third_host_group_mob.host.map(&:name)).to include(vm_host)
+                  expect(vm.cluster).to eq(@second_cluster_name)
+                end
+              end
+            end
+            thread_list.each {|thread| thread.join}
+            expect(get_count_vm_host_affinity_rules(cluster_mob)).to eq(0)
+          end
+        end
+      end
+      context 'and one of the cluster has host group and other has resource pool' do
+        let(:options) do
+          cpi_options(
+            datacenters: [{
+              'datastore_pattern' => @datastore_shared_pattern,
+              'persistent_datastore_pattern' => @datastore_shared_pattern,
+              clusters: [
+                { @cluster_name => { host_group: @second_host_group, } },
+                { @second_cluster_name => { resource_pool: @second_cluster_resource_pool_name, } },
+              ]
+            }]
+          )
+        end
+        let(:cpi) do
+          VSphereCloud::Cloud.new(options)
+        end
+        it 'creates one VM on the second cluster without host group\
+            (as resource pool has more memory available than host group)' do
+          simple_vm_lifecycle(cpi, '', vm_type, get_network_spec) do |vm_id|
+            vm = cpi.vm_provider.find(vm_id)
+            expect(vm.cluster).to eq(@second_cluster_name)
+          end
+          expect(get_count_vm_host_affinity_rules(cluster_mob) +
+            get_count_vm_host_affinity_rules(second_cluster_mob)).to eq(0)
+        end
+        it 'creates multiple VMs (3) one after another on the second cluster\'s resource pool' do
+          vm_list = []
+          begin
+            3.times do
+              vm_id = cpi.create_vm(
+                'agent-007',
+                @stemcell_id,
+                vm_type,
+                get_network_spec,
+                [],
+                {}
+              )
+              expect(vm_id).to_not be_nil
+              vm_list << vm_id
+              vm = cpi.vm_provider.find(vm_id)
+              expect(vm).to_not be_nil
+              expect(vm.cluster).to eq(@second_cluster_name)
+            end
+          ensure
+            vm_list.each do |vm_id|
+              delete_vm(cpi, vm_id)
+            end
+            expect(get_count_vm_host_affinity_rules(cluster_mob) +
+              get_count_vm_host_affinity_rules(second_cluster_mob)).to eq(0)
+          end
+        end
+      end
+    end
+  end
+
+  private
+
+  def find_host_group_mob(host_group_name, clustermob=cluster_mob)
+    clustermob.configuration_ex.group.find do |group|
+      group.name == host_group_name && group.is_a?(VimSdk::Vim::Cluster::HostGroup)
+    end
+  end
+end

--- a/src/vsphere_cpi/spec/support/lifecycle_properties.rb
+++ b/src/vsphere_cpi/spec/support/lifecycle_properties.rb
@@ -87,7 +87,7 @@ module LifecycleProperties
         'clusters' => [
           {
             @default_cluster => {
-              'resource_pool' => @default_resource_pool
+              'resource_pool' => @default_resource_pool,
             }
           }
         ]

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cluster_config_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cluster_config_spec.rb
@@ -4,7 +4,12 @@ module VSphereCloud
   describe ClusterConfig do
     subject(:cluster_config) { described_class.new(name, config) }
     let(:name) { 'fake-cluster-name' }
-    let(:config) { { 'resource_pool' => 'fake-resource-pool' } }
+    let(:config) do
+      {
+        'resource_pool' => 'fake-resource-pool',
+        'host_group' => 'fake-host-group',
+      }
+    end
 
     describe '#name' do
       it 'returns the cluster name' do
@@ -15,6 +20,12 @@ module VSphereCloud
     describe '#resource_pool' do
       it 'returns the resource pool name' do
         expect(cluster_config.resource_pool).to eq('fake-resource-pool')
+      end
+    end
+
+    describe '#host_group' do
+      it 'returns the host group name' do
+        expect(cluster_config.host_group).to eq('fake-host-group')
       end
     end
   end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/drs_rules/drs_lock_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/drs_rules/drs_lock_spec.rb
@@ -48,7 +48,7 @@ describe VSphereCloud::DrsLock, fake_logger: true do
 
       drs_lock.with_drs_lock {}
     end
-
+    
     context 'when block fails' do
       it 'deletes the lock' do
         expect(vm_attribute_manager).to receive(:create).with('drs_lock')

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/drs_rules/vm_group_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/drs_rules/vm_group_spec.rb
@@ -92,6 +92,9 @@ describe VSphereCloud::VmGroup, fake_logger: true do
 
     context 'when vm_group is empty' do
       let(:vms) { [] }
+      before do
+        allow(configuration_ex).to receive(:rule).and_return([])
+      end
       it 'should delete the vm group' do
         with_lock do
           expect(datacenter_cluster).to receive(:reconfigure_ex) do |config|
@@ -104,6 +107,57 @@ describe VSphereCloud::VmGroup, fake_logger: true do
           end.ordered.and_return(task)
         end
         vm_group.delete_vm_groups([vm_group_name])
+      end
+    end
+  end
+
+  describe '#get_delete_rule_spec' do
+    before do
+      allow(datacenter_cluster).to receive(:configuration_ex).and_return(configuration_ex)
+    end
+    context 'when no rule exists' do
+      before do
+        allow(configuration_ex).to receive(:rule).and_return(nil)
+      end
+      it 'returns nil' do
+        expect(vm_group.send(:get_delete_rule_spec, *[vm_groups])).to be_empty
+      end
+    end
+    context 'when no rule exists and rule array is empty' do
+      before do
+        allow(configuration_ex).to receive(:rule).and_return([])
+      end
+      it 'returns empty array' do
+        expect(vm_group.send(:get_delete_rule_spec, *[vm_groups])).to be_empty
+      end
+    end
+    context 'when vm_groups are absent' do
+      before do
+        allow(configuration_ex).to receive(:rule).and_return(['fake-rule'])
+      end
+      it 'returns nil' do
+        expect(vm_group.send(:get_delete_rule_spec, *[[]])).to be_empty
+      end
+    end
+    context 'when vm groups are present' do
+      context 'when there are three rules of which one is deletable' do
+        let(:rule_1) do
+          VimSdk::Vim::Cluster::VmHostRuleInfo.new(key: 'rule_1' , vm_group_name: 'reject-vm-group')
+        end
+        let(:rule_2) do
+          VimSdk::Vim::Cluster::VmHostRuleInfo.new(key: 'rule_2' , vm_group_name: vm_group_name)
+        end
+        let(:rule_3) do
+          instance_double('VimSdk::Vim::Cluster::DependencyRuleInfo', key: 'rule_3')
+        end
+        before do
+          allow(configuration_ex).to receive(:rule).and_return([rule_1, rule_2, rule_3])
+        end
+        it 'return rules spec with one rule that can be deleted' do
+          rules_spec = vm_group.send(:get_delete_rule_spec, *[vm_groups])
+          expect(rules_spec).not_to be(nil)
+          expect(rules_spec.first.remove_key).to eq('rule_2')
+        end
       end
     end
   end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/datastore_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/datastore_spec.rb
@@ -73,7 +73,7 @@ describe VSphereCloud::Resources::Datastore do
   describe '#accessible_from?' do
 
     context 'when a cluster with some hosts is defined' do
-      let (:cluster) { instance_double(VSphereCloud::Resources::Cluster) }
+      let (:cluster) { instance_double(VSphereCloud::Resources::Cluster, host: [host_mob]) }
       let (:host_mob) { instance_double(VimSdk::Vim::HostSystem) }
       let (:host_mount) { instance_double(VimSdk::Vim::Datastore::HostMount, key: host_mob) }
 
@@ -92,7 +92,7 @@ describe VSphereCloud::Resources::Datastore do
 
       context 'when at least one of the hosts is not in maintenance mode' do
         before do
-          expect(cluster).to receive_message_chain(:mob, :host, :include?).with(host_mob).and_return(is_included)
+          expect(cluster).to receive_message_chain(:host, :include?).with(host_mob).and_return(is_included)
         end
         let(:maintenance_mode) { false }
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_config_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_config_spec.rb
@@ -266,7 +266,8 @@ module VSphereCloud
             accessible_datastores: {
               'smaller-ds'=> smaller_ds,
             },
-            mob: cluster1_mob
+            mob: cluster1_mob,
+            host: [host_system],
           )
         end
         let(:cluster_2) do
@@ -276,7 +277,8 @@ module VSphereCloud
             accessible_datastores: {
               'larger-ds' => larger_ds,
             },
-            mob: cluster2_mob
+            mob: cluster2_mob,
+            host: [host_system]
           )
         end
         let(:disk_configurations) do


### PR DESCRIPTION
# Description

This PR enables an Admin to specify a host group in the vSphere clusters. 

This directly enables the Admin to define multiple AZs within the same cluster by using host groups. 

## Impacted Areas in Application
VM Placement & Creation

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

Unit and Integration tests
# Checklist:

- [x] My code follows the standard ruby style guide
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
