### PR TITLE
Nj update gems

### DIFF
--- a/src/vsphere_cpi/Gemfile
+++ b/src/vsphere_cpi/Gemfile
@@ -16,7 +16,7 @@ group :development, :test do
   gem 'parallel_tests'
   gem 'pry'
   gem 'pry-byebug'
-  gem 'rack',      '~> 2.0.1'
+  gem 'rack',      '~> 2.0.6'
   gem 'rake',      '~> 10.0'
   gem 'rspec',     '~> 3.5.0'
   gem 'rspec-its'

--- a/src/vsphere_cpi/Gemfile
+++ b/src/vsphere_cpi/Gemfile
@@ -9,7 +9,7 @@ gem 'mono_logger', '~> 1.1.0'
 gem 'netaddr',     '~> 1.5', '>= 1.5.1'
 gem 'nokogiri',    '~> 1.8.1'
 gem 'oga',         '2.3'
-gem 'typhoeus',    '~> 1.0', '>= 1.0.1'
+gem 'typhoeus',    '~> 1.3.0', '>= 1.3.1'
 
 group :development, :test do
   gem 'fakefs'

--- a/src/vsphere_cpi/Gemfile.lock
+++ b/src/vsphere_cpi/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
-    rack (2.0.5)
+    rack (2.0.6)
     rake (10.5.0)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -92,7 +92,7 @@ DEPENDENCIES
   parallel_tests
   pry
   pry-byebug
-  rack (~> 2.0.1)
+  rack (~> 2.0.6)
   rake (~> 10.0)
   rspec (~> 3.5.0)
   rspec-its
@@ -101,4 +101,4 @@ DEPENDENCIES
   typhoeus (~> 1.0, >= 1.0.1)
 
 BUNDLED WITH
-   1.16.1
+   1.17.1

--- a/src/vsphere_cpi/Gemfile.lock
+++ b/src/vsphere_cpi/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     ethon (0.11.0)
       ffi (>= 1.3.0)
     fakefs (0.14.1)
-    ffi (1.9.23)
+    ffi (1.9.25)
     httpclient (2.8.3)
     json (2.1.0)
     little-plugger (1.1.4)
@@ -72,7 +72,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     timecop (0.8.1)
-    typhoeus (1.3.0)
+    typhoeus (1.3.1)
       ethon (>= 0.9.0)
 
 PLATFORMS
@@ -98,7 +98,7 @@ DEPENDENCIES
   rspec-its
   simplecov
   timecop (~> 0.8.1)
-  typhoeus (~> 1.0, >= 1.0.1)
+  typhoeus (~> 1.3.0, >= 1.3.1)
 
 BUNDLED WITH
    1.17.1


### PR DESCRIPTION
# Description

Update Gem versions

## Related PR and Issues
Fixes Security alert from github about Gems

## Type of change

Please delete options that are not relevant.

Updating rack version - used for testing
Updating ffi version - used by typhoeus which is used by nsx-t

