### PR TITLE
[ACCEPTANCE TESTING IN PROGRESS]Fix Disable DRS to only ADD vm entries

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
@@ -231,13 +231,12 @@ module VSphereCloud
 
     def disable_drs(vm_resource, cluster_resource)
       DrsLock.new('DISABLE_DRS_LOCK').with_drs_lock do
-        drs_vm_spec_exists = !cluster_resource.mob.configuration_ex.drs_vm_config.empty?
-
         drs_vm_spec = VimSdk::Vim::Cluster::DrsVmConfigSpec.new
         drs_vm_spec.info = VimSdk::Vim::Cluster::DrsVmConfigInfo.new
         drs_vm_spec.info.enabled = false
         drs_vm_spec.info.key = vm_resource.mob
-        drs_vm_spec.operation = drs_vm_spec_exists ? VimSdk::Vim::Option::ArrayUpdateSpec::Operation::EDIT : VimSdk::Vim::Option::ArrayUpdateSpec::Operation::ADD
+
+        drs_vm_spec.operation = VimSdk::Vim::Option::ArrayUpdateSpec::Operation::ADD
 
         config_spec = VimSdk::Vim::Cluster::ConfigSpecEx.new
         config_spec.drs_vm_config_spec = [drs_vm_spec]

--- a/src/vsphere_cpi/spec/integration/pin_vm_spec.rb
+++ b/src/vsphere_cpi/spec/integration/pin_vm_spec.rb
@@ -1,6 +1,6 @@
 require 'integration/spec_helper'
 
-context 'when having pin vm enabled' do
+context 'when drs_disabled is set to true in vm_type' do
 
   before (:all) do
     @datacenter_name = fetch_and_verify_datacenter('BOSH_VSPHERE_CPI_DATACENTER')
@@ -19,26 +19,35 @@ context 'when having pin vm enabled' do
     vm_type.merge({'disable_drs' => true})
   end
 
-  it 'creates a VM and PINS it by disabling DRS on it' do
+  it 'creates 2 VMs in parallel and disables DRS on them' do
     begin
-      vm_id = @cpi.create_vm(
-        'agent-007',
-        @stemcell_id,
-        vm_type_with_disable_drs,
-        get_network_spec,
-        [],
-        {}
-      )
+      thread_list = []
+      vm_list = []
+      2.times do
+        thread_list << Thread.new do
+          vm_list << @cpi.create_vm(
+            'agent-007',
+            @stemcell_id,
+            vm_type_with_disable_drs,
+            get_network_spec,
+            [],
+            {}
+          )
+        end
+      end
+      thread_list.each {|thread| thread.join}
 
-      expect(vm_id).to_not be_nil
-      vm = @cpi.vm_provider.find(vm_id)
-      vm_mob = vm.mob
-      cluster = @cpi.datacenter.find_cluster(@cluster_name)
-      cluster_vm_drs_config = cluster.mob.configuration_ex.drs_vm_config.first
-      expect(cluster_vm_drs_config.key.name).to eq(vm_mob.name)
-      expect(cluster_vm_drs_config.enabled).to be false
+      vm_list.each_with_index do |vm_id, index|
+        expect(vm_id).to_not be_nil
+        vm = @cpi.vm_provider.find(vm_id)
+        vm_mob = vm.mob
+        cluster = @cpi.datacenter.find_cluster(@cluster_name)
+        cluster_vm_drs_config = cluster.mob.configuration_ex.drs_vm_config[index]
+        expect(cluster_vm_drs_config.key.name).to eq(vm_mob.name)
+        expect(cluster_vm_drs_config.enabled).to be false
+      end
     ensure
-      delete_vm(@cpi, vm_id)
+      vm_list.each{|vm_id| delete_vm(@cpi, vm_id)}
     end
   end
 end


### PR DESCRIPTION
[#162210846](https://www.pivotaltracker.com/story/show/162210846)

# Description

When adding VMs to DRS VM Overrides in a cluster, the Array update spec operation needs to be only `ADD` not `EDIT` . 

## Related PR and Issues
Fixes # (Self Reported)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Integration test updated to account for parallel and multiple creation of VMs

# Checklist:
- [x] New and existing unit tests pass locally with my changes
