### PR TITLE
De-duplicate NSX security groups

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -347,23 +347,40 @@ module VSphereCloud
         end
 
         begin
-          vm_type.nsx_security_groups.each do |security_group|
-            nsx.add_vm_to_security_group(security_group, created_vm.mob_id)
-          end unless vm_type.nsx_security_groups.nil?
-
 
           if @config.nsx_enabled?
-            bosh_groups = (environment || {}).fetch('bosh', {}).fetch('groups', [])
-            bosh_groups.each do |security_group|
+            all_nsx_security_groups = Set.new
+
+            # Gather all security groups from three sources into a Set
+            # 1. VM Type
+            # 2. BOSH Groups
+            # 3. NSX Load Balancers
+
+            # VM Type
+            vm_type_security_group = vm_type.nsx_security_groups
+            all_nsx_security_groups.merge(vm_type_security_group) unless vm_type_security_group.nil?
+
+            # BOSH Group
+            bosh_groups_security_groups = (environment || {}).fetch('bosh', {}).fetch('groups', [])
+            all_nsx_security_groups.merge(bosh_groups_security_groups) unless bosh_groups_security_groups.nil?
+
+            # Load Balancer
+            unless vm_type.nsx_lbs.nil?
+              nsx_lbs_security_groups = vm_type.nsx_lbs.map { |m| m['security_group'] }
+              all_nsx_security_groups.merge(nsx_lbs_security_groups.compact)
+            end
+
+            # Add vm to security groups
+            all_nsx_security_groups.each do |security_group|
               nsx.add_vm_to_security_group(security_group, created_vm.mob_id)
+            end
+
+            # Add vm to load balancer
+            unless vm_type.nsx_lbs.nil? || vm_type.nsx_lbs.empty?
+              nsx.add_members_to_lbs(vm_type.nsx_lbs)
             end
           end
 
-          unless vm_type.nsx_lbs.nil?
-            security_groups = vm_type.nsx_lbs.map { |m| m['security_group'] }.uniq
-            security_groups.each { |sg| nsx.add_vm_to_security_group(sg, created_vm.mob_id) }
-            nsx.add_members_to_lbs(vm_type.nsx_lbs)
-          end
         rescue => e
           logger.info("Failed to apply NSX properties to VM '#{created_vm.cid}' with error: #{e}")
           begin

--- a/src/vsphere_cpi/lib/cloud/vsphere/nsx.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsx.rb
@@ -33,6 +33,8 @@ module VSphereCloud
                           matching: %r{(?:javax.persistence.OptimisticLockException|<errorCode>300<\/errorCode>|Concurrent object access error)}).retryer do |i|
         logger.debug("Attempting to add VM '#{vm_id}' to Security Group '#{security_group_name}'...")
 
+        # TODO : verify `failIfExists` presence in older releases.
+        #response = @http_client.put("https://#{@nsx_url}/api/2.0/services/securitygroup/#{sg_id}/members/#{vm_id}?failIfExists=false", nil)
         response = @http_client.put("https://#{@nsx_url}/api/2.0/services/securitygroup/#{sg_id}/members/#{vm_id}", nil)
 
         if vm_belongs_to_security_group?(response.body)
@@ -351,7 +353,9 @@ module VSphereCloud
       error_document = Oga.parse_xml(xml_content)
       error_code_element = error_document.xpath('error/errorCode')
 
-      vm_in_security_group = (!error_code_element.empty? && error_code_element.text == '203')
+      # 6.3.x returns error code 203
+      # 6.4.x returns error code 311
+      vm_in_security_group = (!error_code_element.empty? && ['203', '311'].include?(error_code_element.text))
       vm_in_security_group ? true : false
     end
   end

--- a/src/vsphere_cpi/spec/integration/nsx_vsphere_spec.rb
+++ b/src/vsphere_cpi/spec/integration/nsx_vsphere_spec.rb
@@ -171,18 +171,6 @@ describe 'NSX for vsphere integration', nsx_vsphere: true do
         }.to raise_error(/Bad Username or Credentials presented/)
       end
     end
-
-    context 'when there\'s no NSX configuration in the Director\'s manifest' do
-      let(:nsx_options) do
-        cpi_options
-      end
-
-      it 'raises an error' do
-        expect {
-          create_vm_with_vm_type(cpi, vm_type, @stemcell_id)
-        }.to raise_error(/NSX/)
-      end
-    end
   end
 
   context 'when vm_extensions has an NSX load balancer and pool' do

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -719,6 +719,9 @@ module VSphereCloud
       end
 
       context 'when the VM should have security tags' do
+        let(:fake_duplicate_sg) {'fake-security-tag'}
+        let(:another_fake_duplicate_sg) {'another-fake-security-tag'}
+        let(:fake_unique_bosh_group) {'fake-unique-bosh-group'}
         let(:cloud_config) do
           instance_double(
             'VSphereCloud::Config',
@@ -784,6 +787,267 @@ module VSphereCloud
             [],
             environment
           )
+        end
+
+        context 'when VM has duplicate security groups specified in vm_type, lbs and BOSH Groups' do
+          let(:vm_type) do
+            {
+              'cpu' => 1,
+              'ram' => 1024,
+              'disk' => 4096,
+              'nsx' => {
+                'security_groups' => [fake_duplicate_sg, another_fake_duplicate_sg, another_fake_duplicate_sg],
+                'lbs' => [
+                  {
+                    'edge_name' => 'fake-edge',
+                    'pool_name' => 'fake-pool',
+                    'security_group' => fake_duplicate_sg,
+                    'port' => 443,
+                    'monitor_port' => 443,
+                  },
+                  {
+                    'edge_name' => 'fake-edge-2',
+                    'pool_name' => 'fake-pool-2',
+                    'security_group' => fake_duplicate_sg,
+                    'port' => 443,
+                    'monitor_port' => 443,
+                  }
+                ]
+              }
+            }
+          end
+          let(:environment) do
+            {
+              'bosh' => {
+                'groups' => [
+                  fake_duplicate_sg,
+                  another_fake_duplicate_sg,
+                  fake_unique_bosh_group,
+                ]
+              }
+            }
+          end
+          it 'should de-duplicate the security tags and attach them to the VM' do
+            allow(VmConfig).to receive(:new).and_return(vm_config)
+            allow(NsxHttpClient).to receive(:new)
+              .with('fake-nsx-user', 'fake-nsx-password', 'fake-log-file')
+              .and_return(http_basic_auth_client)
+            allow(NSX).to receive(:new).and_return(nsx)
+
+            expect(VmCreator).to receive(:new).and_return(vm_creator)
+            expect(vm_creator).to receive(:create).with(vm_config).and_return(fake_vm)
+            expect(cloud_config).to receive(:validate_nsx_options)
+            expect(nsx).to receive(:add_vm_to_security_group).exactly(3).times
+            allow(nsx).to receive(:add_members_to_lbs)
+            vsphere_cloud.create_vm(
+              'fake-agent-id',
+              'fake-stemcell-cid',
+              vm_type,
+              'fake-networks-hash',
+              [],
+              environment
+            )
+          end
+        end
+
+        context 'when VM has duplicate security groups specified in vm_type, and none in lbs or bosh groups' do
+          let(:vm_type) do
+            {
+              'cpu' => 1,
+              'ram' => 1024,
+              'disk' => 4096,
+              'nsx' => {
+                'security_groups' => [fake_duplicate_sg, another_fake_duplicate_sg, another_fake_duplicate_sg],
+                'lbs' => [
+                  {
+                    'edge_name' => 'fake-edge',
+                    'pool_name' => 'fake-pool',
+                    'port' => 443,
+                    'monitor_port' => 443,
+                  },
+                  {
+                    'edge_name' => 'fake-edge-2',
+                    'pool_name' => 'fake-pool-2',
+                    'port' => 443,
+                    'monitor_port' => 443,
+                  }
+                ]
+              }
+            }
+          end
+          let(:environment) do
+            {
+              'bosh' => {
+                'groups' => [
+                ]
+              }
+            }
+          end
+          it 'should de-duplicate the security tags and attach them to the VM' do
+            allow(VmConfig).to receive(:new).and_return(vm_config)
+            allow(NsxHttpClient).to receive(:new)
+              .with('fake-nsx-user', 'fake-nsx-password', 'fake-log-file')
+              .and_return(http_basic_auth_client)
+            allow(NSX).to receive(:new).and_return(nsx)
+
+            expect(VmCreator).to receive(:new).and_return(vm_creator)
+            expect(vm_creator).to receive(:create).with(vm_config).and_return(fake_vm)
+            expect(cloud_config).to receive(:validate_nsx_options)
+            expect(nsx).to receive(:add_vm_to_security_group).exactly(2).times
+            allow(nsx).to receive(:add_members_to_lbs)
+            vsphere_cloud.create_vm(
+              'fake-agent-id',
+              'fake-stemcell-cid',
+              vm_type,
+              'fake-networks-hash',
+              [],
+              environment
+            )
+          end
+        end
+
+        context 'when VM has duplicate security groups specified lbs but none in vm_type or bosh groups' do
+          let(:vm_type) do
+            {
+              'cpu' => 1,
+              'ram' => 1024,
+              'disk' => 4096,
+              'nsx' => {
+                'lbs' => [
+                  {
+                    'edge_name' => 'fake-edge',
+                    'pool_name' => 'fake-pool',
+                    'security_group' => fake_duplicate_sg,
+                    'port' => 443,
+                    'monitor_port' => 443,
+                  },
+                  {
+                    'edge_name' => 'fake-edge-2',
+                    'pool_name' => 'fake-pool-2',
+                    'security_group' => fake_duplicate_sg,
+                    'port' => 443,
+                    'monitor_port' => 443,
+                  }
+                ]
+              }
+            }
+          end
+          let(:environment) do
+            {
+              'bosh' => {
+              }
+            }
+          end
+          it 'should de-duplicate the security tags and attach them to the VM' do
+            allow(VmConfig).to receive(:new).and_return(vm_config)
+            allow(NsxHttpClient).to receive(:new)
+              .with('fake-nsx-user', 'fake-nsx-password', 'fake-log-file')
+              .and_return(http_basic_auth_client)
+            allow(NSX).to receive(:new).and_return(nsx)
+
+            expect(VmCreator).to receive(:new).and_return(vm_creator)
+            expect(vm_creator).to receive(:create).with(vm_config).and_return(fake_vm)
+            expect(cloud_config).to receive(:validate_nsx_options)
+            expect(nsx).to receive(:add_vm_to_security_group).once
+            allow(nsx).to receive(:add_members_to_lbs)
+            vsphere_cloud.create_vm(
+              'fake-agent-id',
+              'fake-stemcell-cid',
+              vm_type,
+              'fake-networks-hash',
+              [],
+              environment
+            )
+          end
+        end
+
+        context 'when VM has duplicate security groups specified in bosh groups env but none in lbs and vm_type' do
+          let(:vm_type) do
+            {
+              'cpu' => 1,
+              'ram' => 1024,
+              'disk' => 4096,
+              'nsx' => {
+                'security_groups' => [],
+                'lbs' => []
+              }
+            }
+          end
+          let(:environment) do
+            {
+              'bosh' => {
+                'groups' => [
+                  fake_duplicate_sg,
+                  fake_duplicate_sg,
+                  another_fake_duplicate_sg,
+                  another_fake_duplicate_sg,
+                  another_fake_duplicate_sg,
+                  fake_unique_bosh_group,
+                  fake_unique_bosh_group,
+                ]
+              }
+            }
+          end
+          it 'should de-duplicate the security tags and attach them to the VM' do
+            allow(VmConfig).to receive(:new).and_return(vm_config)
+            allow(NsxHttpClient).to receive(:new)
+              .with('fake-nsx-user', 'fake-nsx-password', 'fake-log-file')
+              .and_return(http_basic_auth_client)
+            allow(NSX).to receive(:new).and_return(nsx)
+
+            expect(VmCreator).to receive(:new).and_return(vm_creator)
+            expect(vm_creator).to receive(:create).with(vm_config).and_return(fake_vm)
+            expect(cloud_config).to receive(:validate_nsx_options)
+            expect(nsx).to receive(:add_vm_to_security_group).exactly(3).times
+            vsphere_cloud.create_vm(
+              'fake-agent-id',
+              'fake-stemcell-cid',
+              vm_type,
+              'fake-networks-hash',
+              [],
+              environment
+            )
+          end
+        end
+
+        context 'when VM has no security groups specified in bosh groups env , lbs and vm_type' do
+          let(:vm_type) do
+            {
+              'cpu' => 1,
+              'ram' => 1024,
+              'disk' => 4096,
+              'nsx' => {
+                'security_groups' => [],
+                'lbs' => []
+              }
+            }
+          end
+          let(:environment) do
+            {
+              'bosh' => {
+                'groups' => []
+              }
+            }
+          end
+          it 'should not call add_vm_to_security_group VM' do
+            allow(VmConfig).to receive(:new).and_return(vm_config)
+            allow(NsxHttpClient).to receive(:new)
+              .with('fake-nsx-user', 'fake-nsx-password', 'fake-log-file')
+              .and_return(http_basic_auth_client)
+            allow(NSX).to receive(:new).and_return(nsx)
+
+            expect(VmCreator).to receive(:new).and_return(vm_creator)
+            expect(vm_creator).to receive(:create).with(vm_config).and_return(fake_vm)
+            expect(nsx).to_not receive(:add_vm_to_security_group)
+            vsphere_cloud.create_vm(
+              'fake-agent-id',
+              'fake-stemcell-cid',
+              vm_type,
+              'fake-networks-hash',
+              [],
+              environment
+            )
+          end
         end
       end
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -837,8 +837,10 @@ module VSphereCloud
             expect(VmCreator).to receive(:new).and_return(vm_creator)
             expect(vm_creator).to receive(:create).with(vm_config).and_return(fake_vm)
             expect(cloud_config).to receive(:validate_nsx_options)
-            expect(nsx).to receive(:add_vm_to_security_group).exactly(3).times
             allow(nsx).to receive(:add_members_to_lbs)
+            expect(nsx).to receive(:add_vm_to_security_group).with('fake-security-tag', 'fake-mob-id')
+            expect(nsx).to receive(:add_vm_to_security_group).with('another-fake-security-tag', 'fake-mob-id')
+            expect(nsx).to receive(:add_vm_to_security_group).with('fake-unique-bosh-group', 'fake-mob-id')
             vsphere_cloud.create_vm(
               'fake-agent-id',
               'fake-stemcell-cid',

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/nsx_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/nsx_spec.rb
@@ -67,6 +67,19 @@ module VSphereCloud
         end
       end
 
+      context 'when VM is already part of the Security Group in NSXV-6.4.x' do
+        it 'does not update the Security Group' do
+          expect_POST_security_group_conflict
+          expect_GET_security_groups_happy
+          # NSX-V 6.4.X return a different error code fro duplicate vm entry
+          #  6.4.x returns 311
+          #  6.3.x returns 203
+          expect_PUT_security_group_vm_duplicate_with_311
+
+          nsx.add_vm_to_security_group(sg_name, vm_id)
+        end
+      end
+
       context 'when the create Security Group HTTP request fails' do
         it 'returns an error' do
           expect_POST_security_group_sad
@@ -533,6 +546,12 @@ module VSphereCloud
       put_response = double('response', status: 500, body: "<error><details>The object #{vm_id} is already present in the system.</details><errorCode>203</errorCode><moduleName>core-services</moduleName></error>")
       expect(http_client).to receive(:put).with("https://#{nsx_address}/api/2.0/services/securitygroup/#{sg_id}/members/#{vm_id}", nil)
                                .and_return(put_response)
+    end
+
+    def expect_PUT_security_group_vm_duplicate_with_311
+      put_response = double('response', status: 500, body: "<error><details>The object #{vm_id} is already present in the system.</details><errorCode>311</errorCode><moduleName>core-services</moduleName></error>")
+      expect(http_client).to receive(:put).with("https://#{nsx_address}/api/2.0/services/securitygroup/#{sg_id}/members/#{vm_id}", nil)
+        .and_return(put_response)
     end
 
     def expect_PUT_security_group_vm_sad(error = 'fake-nsx-error')


### PR DESCRIPTION
# Description
Security groups for NSX-V has multiple sources
 - vm_type
 - bosh groups in create_vm env hash
 - nsx lbs

We need to gather all `nsx-security-groups` and deduplicate before calling API to add vm to these `nsx-security-groups`. It saves execution time. More robust code as we do not need to rely on some fragile logic to  not raise error if return code is 203 (`vm` already exists in Security group). 

The issue is caused when upgrading from NSX-V 6.3.x to 6.4.2. 
6.4.2 NSX manager's security group API return code is different from 6.3.x

## Related PR and Issues
Fixes issue `Object vm-32660 is already a member of Security5.`

## Impacted Areas in Application
Adding NSX-Security groups

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x]  Performance Improvement