### PR TITLE
Add CPI extension to Solution Manager

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/cpi_extension.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cpi_extension.rb
@@ -37,6 +37,7 @@ module VSphereCloud
       cpi_extension.key = key
       cpi_extension.version = version
       cpi_extension.last_heartbeat_time = option[:last_heartbeat] || Time.now.iso8601
+      cpi_extension.shown_in_solution_manager = true
 
       cpi_extension_desc = VimSdk::Vim::Description.new
       cpi_extension_desc.label = label

--- a/src/vsphere_cpi/spec/integration/cpi_extension_spec.rb
+++ b/src/vsphere_cpi/spec/integration/cpi_extension_spec.rb
@@ -36,8 +36,12 @@ describe '#add cpi extension' do
     it 'adds an extension to vcenter and attaches stemcell to that extension' do
       begin
         stemcell_id = upload_stemcell(cpi)
-        stemcell_vm = @cpi.client.find_vm_by_name(@cpi.datacenter.mob, stemcell_id)
-        expect(stemcell_vm.config.managed_by.extension_key).to eql(VSphereCloud::VCPIExtension::DEFAULT_VSPHERE_CPI_EXTENSION_KEY)
+        stemcell_vm = @cpi.client.find_vm_by_name(@cpi.datacenter.mob,
+                                                  stemcell_id)
+        key = stemcell_vm.config.managed_by.extension_key
+        ext = @cpi.client.service_content.extension_manager.find_extension(key)
+        expect(key).to eql(VSphereCloud::VCPIExtension::DEFAULT_VSPHERE_CPI_EXTENSION_KEY)
+        expect(ext.shown_in_solution_manager).to be true
       ensure
         cpi.delete_stemcell(stemcell_id)
       end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cpi_extension_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cpi_extension_spec.rb
@@ -30,6 +30,7 @@ module VSphereCloud
         expect(extension.key). to eq('Foo')
         expect(extension.version).to eq('Bar')
         expect(extension.description.label).to eq(subject::DEFAULT_VSPHERE_CPI_EXTENSION_LABEL)
+        expect(extension.shown_in_solution_manager).to be true
       end
     end
 


### PR DESCRIPTION

# Description
- Earlier CPI used to have an extension to throw warnings when an Admin
tries to modify and CPI created VM. Now this extension is visible in
the solution manager where all the associated stemcells and VMs can be seen in
the UI.

[#162394489](https://www.pivotaltracker.com/story/show/162394489)

## Impacted Areas in Application
CPI Extensions

## Type of change
Feature 

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Unit & Integration

**Test Configuration**:
Make sure environment does not have existing extension.

# Checklist:
- [x] My code follows the standard ruby style guide
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
