### PR TITLE
[Test in Progress] Folder up disks while attaching them

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere.rb
@@ -67,6 +67,7 @@ require 'cloud/vsphere/nsxt_helpers/nsxt_ip_block_provider'
 require 'cloud/vsphere/selection_pipeline'
 require 'cloud/vsphere/disk_placement_selection_pipeline'
 require 'cloud/vsphere/vm_placement_selection_pipeline'
+require 'cloud/vsphere/vm_sdrs_configurator'
 
 
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -424,7 +424,7 @@ module VSphereCloud
 
         persistent_disks = vm.persistent_disks
         unless persistent_disks.empty?
-          vm.detach_disks(persistent_disks)
+          vm.detach_disks(persistent_disks, @datacenter.disk_path)
         end
 
         # Delete env.iso and VM specific files managed by the director
@@ -520,6 +520,8 @@ module VSphereCloud
 
         disk_is_in_target_datastore = disk_config.existing_datastore_name =~ Regexp.new(disk_config.target_datastore_pattern)
 
+        destination_datastore = accessible_datastores[disk_config.existing_datastore_name]
+
         unless disk_is_accessible && disk_is_in_target_datastore
           # Create a new disk selection pipeline with a gathering block.
           pipeline = DiskPlacementSelectionPipeline.new(disk_config.size,
@@ -535,8 +537,11 @@ module VSphereCloud
           storage_placement = storage_placement_enum.first
           raise "Unable to attach disk to the VM. There is no datastore matching pattern or required space available for disk to move" if storage_placement.nil?
           destination_datastore = @datacenter.find_datastore(storage_placement.name)
-          disk_to_attach = @datacenter.move_disk_to_datastore(disk_to_attach, destination_datastore)
         end
+
+        # The destination datastore might or might not have changed depending on the accessibility from vm with vm_cid.
+        # Action of attaching a disk folders it up inside the vm_cid named folder inside bosh disk folder
+        disk_to_attach = @datacenter.move_disk_to_datastore(disk_to_attach, destination_datastore, vm_cid)
 
         disk_spec = vm.attach_disk(disk_to_attach)
         # Overwrite cid with the director cid
@@ -555,7 +560,7 @@ module VSphereCloud
         disk = vm.disk_by_cid(director_disk_cid.value)
         raise Bosh::Clouds::DiskNotAttached.new(true), "Disk '#{director_disk_cid.value}' is not attached to VM '#{vm_cid}'" if disk.nil?
 
-        vm.detach_disks([disk])
+        vm.detach_disks([disk], datacenter.disk_path)
         delete_disk_from_agent_env(vm, director_disk_cid)
       end
     end

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/datacenter.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/datacenter.rb
@@ -186,7 +186,7 @@ module VSphereCloud
       #
       # @return [VSphereCloud::Resources::PersistentDisk] The new disk object with updated datastore & folder name
       def move_disk_to_datastore(disk, destination_datastore, vm_cid=nil)
-        disk_folder = vm_cid.nil? ? disk_path : vm_cid
+        disk_folder = vm_cid.nil? ? disk_path : "#{disk_path}/#{vm_cid}"
         destination_path = "[#{destination_datastore.name}] #{disk_folder}/#{disk.cid}.vmdk"
         logger.info("Moving #{disk.path} to #{destination_path}")
         @client.move_disk(mob, disk.path, mob, destination_path)

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
@@ -293,6 +293,9 @@ module VSphereCloud
         disks_to_move.each do |disk|
           current_datastore = disk.backing.file_name.match(/^\[([^\]]+)\]/)[1]
           original_disk_path = get_old_disk_filepath(disk.key)
+          # Fall back to file path on backing info if vApp properties are missing.
+          # @TODO: Can vApp properties be deleted or disabled? Why?
+          original_disk_path = disk.backing.file_name if original_disk_path.nil?
           dest_filename = original_disk_path.match(/^\[[^\]]+\] (.*)/)[1].split('/')[1]
           dest_path = "[#{current_datastore}] #{restore_path}/#{dest_filename}"
           logger.info("Moving #{disk.backing.file_name} to #{dest_path}")

--- a/src/vsphere_cpi/lib/cloud/vsphere/vcenter_client.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vcenter_client.rb
@@ -324,9 +324,10 @@ module VSphereCloud
       datastore_path = "[#{datastore.name}] #{disk_folder}"
       logger.debug("Trying to find disk in : #{datastore_path}")
       result = wait_for_task do
-        datastore.mob.browser.search(datastore_path, search_spec)
+        datastore.mob.browser.search_sub_folders(datastore_path, search_spec)
       end
-      disk_infos = result.file
+
+      disk_infos = result.first.file
       return nil if disk_infos.empty?
 
       disk_infos.first.capacity_kb / 1024
@@ -458,6 +459,11 @@ module VSphereCloud
       find_child_by_name(mob.child_entity.find {|c| c.name == child_entity_name }, child_path)
     end
 
+    def create_parent_folder(datacenter_mob, disk_path)
+      destination_folder = File.dirname(disk_path)
+      create_datastore_folder(destination_folder, datacenter_mob)
+    end
+
     private
 
     def find_perf_metric_names(mob, names)
@@ -489,11 +495,6 @@ module VSphereCloud
       result = {}
       metrics.each { |metric| result[metric_names[metric.counter_id]] = metric }
       result
-    end
-
-    def create_parent_folder(datacenter_mob, disk_path)
-      destination_folder = File.dirname(disk_path)
-      create_datastore_folder(destination_folder, datacenter_mob)
     end
   end
 end

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
@@ -51,7 +51,7 @@ module VSphereCloud
         if datastore_cluster
           datastore = Resources::Datastore.build_from_client(@client, replicated_stemcell_properties['datastore']).first
         end
-        replicated_stemcell_vm = Resources::VM.new(vm_config.stemcell_cid, replicated_stemcell_vm_mob, @client)
+        replicated_stemcell_vm = Resources::VM.new(vm_config.stemcell_cid, replicated_stemcell_vm_mob, @client, @datacenter)
         snapshot = replicated_stemcell_properties['snapshot']
 
         # Create device_change config
@@ -162,7 +162,7 @@ module VSphereCloud
         end
         next if created_vm_mob.nil?
 
-        created_vm = Resources::VM.new(vm_config.name, created_vm_mob, @client)
+        created_vm = Resources::VM.new(vm_config.name, created_vm_mob, @client, @datacenter)
 
         # Set agent env settings
         begin

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_provider.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_provider.rb
@@ -9,7 +9,7 @@ module VSphereCloud
       vm_mob = @client.find_vm_by_name(@datacenter.mob, vm_cid)
       raise Bosh::Clouds::VMNotFound, "VM '#{vm_cid}' not found in datacenter '#{@datacenter.name}'" if vm_mob.nil?
 
-      Resources::VM.new(vm_cid, vm_mob, @client)
+      Resources::VM.new(vm_cid, vm_mob, @client, @datacenter)
     end
   end
 end

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_sdrs_configurator.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_sdrs_configurator.rb
@@ -1,0 +1,68 @@
+module VSphereCloud
+  class VMSDRSConfigurator
+    include Logger
+
+    def initialize(client, datastores, vm_mob)
+      @client =  client
+      @datastores = datastores
+      @vm = vm_mob
+    end
+
+    def with_sdrs_disabled
+      @datastores.each do |ds_mob|
+        disable_sdrs_for_ds(ds_mob)
+      end
+      begin
+        yield
+      ensure
+        @datastores.each do |ds_mob|
+          enable_sdrs_for_ds(ds_mob)
+        end
+      end
+    end
+
+    def disable_sdrs_for_ds(ds_mob)
+      parent_datstastore = ds_mob.parent
+      unless parent_datstastore.is_a?(VimSdk::Vim::StoragePod)
+        logger.info("Datastore #{@datastore.name} is not part of any storage pod. No need to disable SDRS")
+        return
+      end
+      disable_sdrs_for_pod(parent_datstastore)
+    end
+
+    def enable_sdrs_for_ds(ds_mob)
+      parent_datstastore = ds_mob.parent
+      unless parent_datstastore.is_a?(VimSdk::Vim::StoragePod)
+        logger.info("Datastore #{ds_mob.name} is not part of any storage pod. No need to enable SDRS")
+        return
+      end
+      enable_sdrs_for_pod(parent_datstastore)
+    end
+
+    private
+
+    def enable_sdrs_for_pod(storage_pod_mob)
+      logger.info("Enabling Storage DRS on #{@vm.name} for storage pod #{storage_pod_mob.name}")
+      vm_info = VimSdk::Vim::StorageDrs::VmConfigInfo.new(vm: @vm, enabled: true)
+      vm_config_spec = VimSdk::Vim::StorageDrs::VmConfigSpec.new(info: vm_info, operation: VimSdk::Vim::Option::ArrayUpdateSpec::Operation::EDIT)
+      storage_drs_config_spec = VimSdk::Vim::StorageDrs::ConfigSpec.new(vm_config_spec: [vm_config_spec])
+      srm = client.service_instance.content.storage_resource_manager
+      @client.wait_for_task do
+        srm.configure_storage_drs_for_pod(storage_pod_mob, storage_drs_config_spec, true)
+      end
+      logger.info("Enabled Storage DRS on #{@vm.name} for storage pod #{storage_pod_mob.name}")
+    end
+
+    def disable_sdrs_for_pod(storage_pod_mob)
+      logger.info("Disabling Storage DRS on #{@vm.name} for storage pod #{storage_pod_mob.name}")
+      vm_info = VimSdk::Vim::StorageDrs::VmConfigInfo.new(vm: @vm, enabled: false)
+      vm_config_spec = VimSdk::Vim::StorageDrs::VmConfigSpec.new(info: vm_info, operation: VimSdk::Vim::Option::ArrayUpdateSpec::Operation::EDIT)
+      storage_drs_config_spec = VimSdk::Vim::StorageDrs::ConfigSpec.new(vm_config_spec: [vm_config_spec])
+      srm = @client.service_instance.content.storage_resource_manager
+      @client.wait_for_task do
+        srm.configure_storage_drs_for_pod(storage_pod_mob, storage_drs_config_spec, true)
+      end
+      logger.info("Disabled Storage DRS on #{@vm.name} for storage pod #{storage_pod_mob.name}")
+    end
+  end
+end

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_sdrs_configurator.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_sdrs_configurator.rb
@@ -24,7 +24,7 @@ module VSphereCloud
     def disable_sdrs_for_ds(ds_mob)
       parent_datstastore = ds_mob.parent
       unless parent_datstastore.is_a?(VimSdk::Vim::StoragePod)
-        logger.info("Datastore #{@datastore.name} is not part of any storage pod. No need to disable SDRS")
+        logger.info("Datastore #{ds_mob.name} is not part of any storage pod. No need to disable SDRS")
         return
       end
       disable_sdrs_for_pod(parent_datstastore)

--- a/src/vsphere_cpi/spec/integration/disk_cloud_properties_spec.rb
+++ b/src/vsphere_cpi/spec/integration/disk_cloud_properties_spec.rb
@@ -79,7 +79,7 @@ describe 'cloud_properties related to disks' do
         expect(backing.disk_mode).to eq(VimSdk::Vim::Vm::Device::VirtualDiskOption::DiskMode::INDEPENDENT_PERSISTENT)
         # default is 'preallocated', thin + lazy-zeroed
         expect(backing.thin_provisioned).to be(false)
-        expect(backing.eagerly_scrub).to be_falsey
+        expect(backing.eagerly_scrub).to be(true)
       end
     ensure
       delete_disk(cpi, disk_id)

--- a/src/vsphere_cpi/spec/integration/disk_foldering_spec.rb
+++ b/src/vsphere_cpi/spec/integration/disk_foldering_spec.rb
@@ -1,0 +1,136 @@
+require 'integration/spec_helper'
+require 'rspec/expectations'
+
+# Custom matcher to search for disk's existence inside search folder passed
+#  * Search uses Datacenter's find_disk method with some patching
+#  * Responds to
+#       - expect(disk_id).to be_inside_folder(cpi: @cpi, search_folder: "XXX/YYY/ZZZ")
+#
+# @return Boolean if it finds a matching disk inside search folder, returns true else false
+RSpec::Matchers.define :be_inside_folder do |**kwargs|
+  match do |disk_cid|
+    disk = nil
+    cpi = kwargs[:cpi]
+    search_folder = kwargs[:search_folder]
+    begin
+      # Monkey Patch Datacenter's default disk path to search_path passed.
+      old_disk_path = cpi.datacenter.instance_variable_get(:@disk_path)
+      cpi.datacenter.instance_variable_set(:@disk_path, search_folder)
+      disk = cpi.datacenter.find_disk(VSphereCloud::DirectorDiskCID.new(disk_cid))
+    rescue Bosh::Clouds::DiskNotFound
+    ensure
+      # Un Monkey Patch disk path
+      cpi.datacenter.instance_variable_set(:@disk_path, old_disk_path)
+    end
+    # The second part of && below is to make sure that disk found above is
+    # present in the search folder passed to matcher.
+    #
+    # If find_vm_by_disk_cid method is called in find_disk method.
+    # It might find the disk in location other than search_folder.
+    # But our matcher is intended to return true only if disk is directly
+    # present in search_folder
+    !disk.nil? && disk.folder == search_folder
+  end
+end
+
+describe 'Selecting & creating datastore folder for persistent disks' do
+  before (:all) do
+    @cluster_name = fetch_and_verify_cluster('BOSH_VSPHERE_CPI_CLUSTER')
+    @datastore_pattern = fetch_and_verify_datastore('BOSH_VSPHERE_CPI_DATASTORE_PATTERN', @cluster_name)
+    @second_datastore = fetch_and_verify_datastore('BOSH_VSPHERE_CPI_SECOND_DATASTORE', @cluster_name)
+    @shared_datastore = fetch_and_verify_datastore('BOSH_VSPHERE_CPI_SHARED_DATASTORE', @cluster_name)
+    @disk_restore_path = fetch_property('BOSH_VSPHERE_CPI_DISK_PATH')
+    verify_non_overlapping_datastores(
+        cpi_options,
+        @datastore_pattern,
+        'BOSH_VSPHERE_CPI_DATASTORE_PATTERN',
+        @second_datastore,
+        'BOSH_VSPHERE_CPI_SECOND_DATASTORE'
+    )
+  end
+
+  let(:network_spec) do
+    {
+        'static' => {
+            'ip' => "169.254.#{rand(1..254)}.#{rand(4..254)}",
+            'netmask' => '255.255.254.0',
+            'cloud_properties' => {'name' => @vlan},
+            'default' => ['dns', 'gateway'],
+            'dns' => ['169.254.1.2'],
+            'gateway' => '169.254.1.3'
+        }
+    }
+  end
+
+  let(:vm_type) do
+    {
+        'ram' => 512,
+        'disk' => 2048,
+        'cpu' => 1,
+    }
+  end
+
+  let(:options) do
+    options = cpi_options(
+        datacenters: [{persistent_datastore_pattern: @shared_datastore}],
+        )
+  end
+
+
+  it 'creates a persistent disk in default datacenter disk folder (Global Properties)' do
+    cpi = VSphereCloud::Cloud.new(options)
+    begin
+      disk_id = cpi.create_disk(128, {})
+      expect(cpi.has_disk?(disk_id)).to be(true)
+      expect(disk_id).to be_inside_folder(cpi: cpi, search_folder: "vcpi-disk-folder")
+    ensure
+      delete_disk(cpi, disk_id)
+    end
+  end
+
+  context 'when attaching a disk to VM on the different datastore' do
+    it 'moves the disk to vm-cid named folder parallel to the master disk folder and moves back to master disk folder when disk is detached' do
+      cpi = VSphereCloud::Cloud.new(options)
+      begin
+        vm_id = cpi.create_vm(
+            'agent-007',
+            @stemcell_id,
+            vm_type,
+            network_spec,
+            [],
+            {}
+        )
+        expect(vm_id).to_not be_nil
+        vm = cpi.vm_provider.find(vm_id)
+        expect(vm).to_not be_nil
+
+        disk_id = cpi.create_disk(128, {})
+        expect(cpi.has_disk?(disk_id)).to be(true)
+        expect(disk_id).to be_inside_folder(cpi: cpi, search_folder: "vcpi-disk-folder")
+
+        cpi.attach_disk(vm_id, disk_id)
+        expect(disk_id).to be_inside_folder(cpi: cpi, search_folder: "#{vm_id}")
+
+        # Detach the disk.
+        cpi.detach_disk(vm_id, disk_id)
+        # it should be back in the master disk folder and should not be in a vm folder
+        expect(disk_id).to be_inside_folder(cpi: cpi, search_folder: "vcpi-disk-folder")
+        expect(disk_id).to_not be_inside_folder(cpi: cpi, search_folder: "vcpi-disk-folder/#{vm_id}")
+
+        # Attach the disk again
+        cpi.attach_disk(vm_id, disk_id)
+        # should be back in vm folder
+        expect(disk_id).to be_inside_folder(cpi: cpi, search_folder: "#{vm_id}")
+
+        # Delete the VM
+        delete_vm(cpi, vm_id)
+        # it should be back in the master disk folder and should not be in the vm folder
+        expect(disk_id).to be_inside_folder(cpi: cpi, search_folder: "vcpi-disk-folder/")
+        expect(disk_id).to_not be_inside_folder(cpi: cpi, search_folder: "vcpi-disk-folder/#{vm_id}")
+      ensure
+        delete_vm(cpi, vm_id)
+        delete_disk(cpi, disk_id)
+      end
+    end
+  end
+end

--- a/src/vsphere_cpi/spec/integration/disk_reattachment_spec.rb
+++ b/src/vsphere_cpi/spec/integration/disk_reattachment_spec.rb
@@ -48,13 +48,27 @@ describe 're-attaching a persistent disk' do
       disk_id = @cpi.create_disk(2048, {}, vm_id)
       expect(disk_id).to_not be_nil
 
+      disk_id_1 = @cpi.create_disk(2048, {}, vm_id)
+      expect(disk_id).to_not be_nil
+
+      disk_id_2 = @cpi.create_disk(2048, {}, vm_id)
+      expect(disk_id).to_not be_nil
+
       @cpi.attach_disk(vm_id, disk_id)
+      require 'pry-byebug'
+      binding.pry
       @cpi.detach_disk(vm_id, disk_id)
       @cpi.attach_disk(vm_id, disk_id)
+      @cpi.attach_disk(vm_id, disk_id_1)
+      @cpi.attach_disk(vm_id, disk_id_2)
       @cpi.detach_disk(vm_id, disk_id)
+      @cpi.detach_disk(vm_id, disk_id_1)
+      @cpi.detach_disk(vm_id, disk_id_2)
     ensure
       delete_vm(@cpi, vm_id)
       delete_disk(@cpi, disk_id)
+      delete_disk(@cpi, disk_id_1)
+      delete_disk(@cpi, disk_id_2)
     end
   end
 

--- a/src/vsphere_cpi/spec/integration/host_local_spec.rb
+++ b/src/vsphere_cpi/spec/integration/host_local_spec.rb
@@ -174,8 +174,8 @@ describe 'host-local storage patterns', :host_local => true do
 
           host_local_datastores = matching_datastores(local_disk_cpi.datacenter, @multi_local_ds_pattern)
           other_datastore = host_local_datastores.values.find { |ds| ds.name != ephemeral_ds }
-          disk = local_disk_cpi.datacenter.move_disk_to_datastore(disk, other_datastore)
-          expect(disk.datastore.name).to_not eq(ephemeral_ds)
+          destination_path = "[#{other_datastore.name}] #{local_disk_cpi.datacenter.instance_variable_get(:@disk_path)}/#{disk.cid}.vmdk"
+          local_disk_cpi.client.move_disk(local_disk_cpi.datacenter.mob, disk.path, local_disk_cpi.datacenter.mob, destination_path)
 
           local_disk_cpi.attach_disk(vm_id, disk_id)
           expect(local_disk_cpi.has_disk?(disk_id)).to be(true)

--- a/src/vsphere_cpi/spec/integration/logging_spec.rb
+++ b/src/vsphere_cpi/spec/integration/logging_spec.rb
@@ -25,7 +25,7 @@ context 'debug logging' do
   end
 
   let(:password) do
-    ENV.fetch('BOSH_VSPHERE_CPI_PASSWORD')
+    /\b#{Regexp.escape(ENV.fetch('BOSH_VSPHERE_CPI_PASSWORD'))}\b/
   end
 
   let(:logger) do
@@ -55,7 +55,9 @@ context 'debug logging' do
       expect(log.string).to include('POST')        # ensure HTTP logs are included
       expect(log.string).to include('redacted')    # ensure password is redacted
 
-      if log.string.include?(password)
+      # Some password matching vSphere password might get caught if we use include? method.
+      # Using regex enclosed by word boundary will be able to detect these cases.
+      if log.string.match?(password)
         fail 'Expected CPI log to not contain the contents of $BOSH_VSPHERE_CPI_PASSWORD but it did.'
       end
       expect(log.string).to_not include('my-fake-secret')
@@ -76,7 +78,7 @@ context 'debug logging' do
       expect(log.string).to include("Creating vm") # ensure .debug logs are included
       expect(log.string).to_not include("POST")        # ensure HTTP logs are included
 
-      if log.string.include?(password)
+      if log.string.match?(password)
         fail 'Expected CPI log to not contain the contents of $BOSH_VSPHERE_CPI_PASSWORD but it did.'
       end
       expect(log.string).to_not include('my-fake-secret')

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -1384,8 +1384,6 @@ module VSphereCloud
             expect(env_location).to eq(vm_location)
             expect(env['disks']['persistent']['disk-cid']).to eq('some-unit-number')
           end
-          expect(datacenter).to receive(:move_disk_to_datastore).with(disk, datastore_with_disk, vm_cid)
-                                    .and_return(moved_disk)
           vsphere_cloud.attach_disk(vm_cid, 'disk-cid')
         end
 
@@ -1408,8 +1406,6 @@ module VSphereCloud
             expect(env_location).to eq(vm_location)
             expect(env['disks']['persistent'][disk_cid_with_metadata]).to eq('some-unit-number')
           end
-          expect(datacenter).to receive(:move_disk_to_datastore).with(disk, datastore_with_disk, vm_cid)
-                                    .and_return(moved_disk)
           vsphere_cloud.attach_disk('fake-vm-cid', disk_cid_with_metadata)
         end
       end
@@ -1442,7 +1438,7 @@ module VSphereCloud
         it 'moves the disk to an accessible datastore and attaches it' do
           expect(datacenter).to receive(:find_disk).with(director_disk_cid, vm).and_return(disk)
           expect(VSphereCloud::DirectorDiskCID).to receive(:new).with('disk-cid').and_return(director_disk_cid)
-          expect(datacenter).to receive(:move_disk_to_datastore).with(disk, datastore_without_disk, 'fake-vm-cid')
+          expect(datacenter).to receive(:move_disk_to_datastore).with(disk, datastore_without_disk)
             .and_return(moved_disk)
 
           expect(vm).to receive(:attach_disk).with(moved_disk)
@@ -1474,7 +1470,7 @@ module VSphereCloud
           expect(datacenter).to receive(:find_disk).with(director_disk_cid, vm).and_return(disk)
           expect(VSphereCloud::DirectorDiskCID).to receive(:new).with('disk-cid').and_return(director_disk_cid)
 
-          expect(datacenter).to receive(:move_disk_to_datastore).with(disk, datastore_without_disk, 'fake-vm-cid')
+          expect(datacenter).to receive(:move_disk_to_datastore).with(disk, datastore_without_disk)
             .and_return(moved_disk)
 
           expect(vm).to receive(:attach_disk).with(moved_disk)
@@ -1526,7 +1522,7 @@ module VSphereCloud
         it 'extracts the pattern and uses it for datastore picking' do
           expect(datacenter).to receive(:find_datastore).with('target-datastore').and_return(target_datastore)
 
-          expect(datacenter).to receive(:move_disk_to_datastore).with(disk, target_datastore, 'fake-vm-cid')
+          expect(datacenter).to receive(:move_disk_to_datastore).with(disk, target_datastore)
             .and_return(moved_disk)
 
           allow(vm).to receive(:attach_disk).with(moved_disk)
@@ -1563,7 +1559,7 @@ module VSphereCloud
         }
 
         it 'detaches persistent disks' do
-          expect(vm).to receive(:detach_disks).with([disk], restore_path)
+          expect(vm).to receive(:detach_disks).with([disk])
           expect(vm).to receive(:power_off)
           expect(vm).to receive(:delete)
           vsphere_cloud.delete_vm('vm-id')
@@ -1672,7 +1668,7 @@ module VSphereCloud
               vm_location,
               {'disks' => {'persistent' => {}}}
             )
-          expect(vm).to receive(:detach_disks).with([attached_disk], restore_path)
+          expect(vm).to receive(:detach_disks).with([attached_disk])
           vsphere_cloud.detach_disk('vm-id', 'disk-cid')
         end
 
@@ -1683,7 +1679,7 @@ module VSphereCloud
 
           it 'does not update VM with new setting' do
             expect(agent_env).to_not receive(:set_env)
-            expect(vm).to receive(:detach_disks).with([attached_disk], restore_path)
+            expect(vm).to receive(:detach_disks).with([attached_disk])
             vsphere_cloud.detach_disk('vm-id', 'disk-cid')
           end
         end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/datacenter_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/datacenter_spec.rb
@@ -496,16 +496,17 @@ describe VSphereCloud::Resources::Datacenter, fake_logger: true do
         size_in_mb: 1024,
       )
     end
+    let(:vm_cid) {'vm-fake-vm'}
     it 'forwards the call to the client with the correct args' do
-      target_path = "[#{datastore.name}] fake-disk-path/fake-disk-cid.vmdk"
+      target_path = "[#{datastore.name}] #{vm_cid}/fake-disk-cid.vmdk"
       expect(client).to receive(:move_disk).with(datacenter_mob, disk.path, datacenter_mob, target_path)
       expect(VSphereCloud::Resources::PersistentDisk).to receive(:new).with(
         cid: 'fake-disk-cid',
         size_in_mb: 1024,
         datastore: datastore,
-        folder: 'fake-disk-path'
+        folder: "#{vm_cid}"
       ).and_call_original
-      new_disk = datacenter.move_disk_to_datastore(disk, datastore)
+      new_disk = datacenter.move_disk_to_datastore(disk, datastore, vm_cid)
       expect(new_disk.path).to eq(target_path)
     end
   end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/datacenter_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/datacenter_spec.rb
@@ -434,7 +434,7 @@ describe VSphereCloud::Resources::Datacenter, fake_logger: true do
 
         before do
           expect(client).to receive(:find_vm_by_disk_cid).with(datacenter_mob, 'disk-cid').and_return(vm_mob)
-          expect(VSphereCloud::Resources::VM).to receive(:new).with('fake-vm-name', vm_mob, client).and_return(vm)
+          expect(VSphereCloud::Resources::VM).to receive(:new).with('fake-vm-name', vm_mob, client, subject).and_return(vm)
         end
 
         # unexpected event has destroyed the disk


### PR DESCRIPTION
- Objective of the change is to prevent SDRS from running into file
conflicts while relocating VM.
- Unfolder disk to bosh disk folder when detaching them
 - Remove has_persistent_disk_property_mismatch function for no usage
 - move_persistent_disk_to_datastore function now takes a  VM CID as
 required argument. Since it is acalled from only one place the change
 should be good.

