### PR TITLE
[POC][Expermental] Inventorization of VMs by deployment name.

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere.rb
@@ -71,8 +71,8 @@ require 'cloud/vsphere/vm_placement_selection_pipeline'
 
 
 module Bosh
-  module Clouds
-    class VSphere
+    module Clouds
+      class VSphere
       extend Forwardable
 
       def_delegators :@delegate,

--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -450,7 +450,7 @@ module VSphereCloud
           # The below should never happen as parent folder must be there.
           break if  vm_exists(vm_folder_mob) || vm_folder_mob.nil?
           # Delete the folder if it does not contain any more VMs.
-          wait_for_task do
+          @client.wait_for_task do
             vm_folder_mob.unregister_and_destroy
           end
         end

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
@@ -21,6 +21,12 @@ module VSphereCloud
         "<VM: #{@mob} / #{@cid}>"
       end
 
+      def get_custom_field_value(key)
+        mob.custom_value.find do |field|
+          field.key == key
+        end.value
+      end
+
       def cluster
         cluster = cloud_searcher.get_properties(host_properties['parent'], Vim::ClusterComputeResource, 'name', ensure_all: true)
         cluster['name']

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
@@ -21,9 +21,17 @@ module VSphereCloud
         "<VM: #{@mob} / #{@cid}>"
       end
 
-      def get_custom_field_value(key)
+      def get_custom_field_value(key_name)
+        # get the integer key value for the field
+        key_id = @client.service_content.custom_fields_manager.field.map do |field|
+          [field.key, field.name]
+        end&.find do |k, v|
+          v == key_name
+        end[0]
+
+        # get the value of the field
         mob.custom_value.find do |field|
-          field.key == key
+          field.key == key_id
         end.value
       end
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
@@ -56,8 +56,8 @@ module VSphereCloud
       @manifest_params[:networks_spec] || {}
     end
 
-    def vm_folder_name
-      @manifest_params[:vm_folder]
+    def deployment_name
+      @manifest_params[:deployment_name]
     end
 
     def vsphere_networks

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
@@ -56,6 +56,10 @@ module VSphereCloud
       @manifest_params[:networks_spec] || {}
     end
 
+    def vm_folder_name
+      @manifest_params[:vm_folder]
+    end
+
     def vsphere_networks
       networks_map = {}
       networks_spec.each_value do |network_spec|

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
@@ -159,6 +159,8 @@ module VSphereCloud
         #   6. Take a lock
         #   7. Remove Custom field def
 
+        # Blocks do not retain
+        created_vm_mob = nil
         DrsLock.new(VSphereCloud::CLONE_VM_FOLDER_SETUP_LOCK).with_drs_lock do
           this_vm_folder = vm_config.deployment_name.nil? ? base_vm_folder : VSphereCloud::Resources::Folder.new([base_vm_folder.path, vm_config.deployment_name].join('/'), @client, @datacenter.name)
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
@@ -144,13 +144,18 @@ module VSphereCloud
           raise "Failed to find a healthy host in #{cluster.host_group} to create the VM." if host.nil?
         end
 
+        # Before Cloning ready the folder structure
+
+        # Get the last folder in folder path passed in global config
+        base_vm_folder = @datacenter.vm_folder
+        this_vm_folder = vm_config.vm_folder_name.nil? ? base_vm_folder : VSphereCloud::Resources::Folder.new([base_vm_folder.path, vm_config.vm_folder_name].join('/'), @client, @datacenter.name)
 
         # Clone VM
         logger.info("Cloning vm: #{replicated_stemcell_vm} to #{vm_config.name}")
         created_vm_mob = @client.wait_for_task do
           @cpi.clone_vm(replicated_stemcell_vm.mob,
             vm_config.name,
-            @datacenter.vm_folder.mob,
+            this_vm_folder.mob,
             cluster.resource_pool.mob,
             datastore: datastore.mob,
             host: host,

--- a/src/vsphere_cpi/spec/integration/cluster_cloud_properties_spec.rb
+++ b/src/vsphere_cpi/spec/integration/cluster_cloud_properties_spec.rb
@@ -61,22 +61,57 @@ describe 'cloud_properties related to clusters' do
     it 'creates vm in cluster defined in `vm_type`' do
       cpi = VSphereCloud::Cloud.new(options)
       begin
-        vm_id = cpi.create_vm(
+        vm_ids = []
+        vm_ids << cpi.create_vm(
           'agent-007',
           @stemcell_id,
           vm_type,
           network_spec,
           [],
-          {}
+          {'bosh' => {'groups' => %w[director, Zookeeper]}}
         )
-        expect(vm_id).to_not be_nil
 
-        vm = cpi.vm_provider.find(vm_id)
-        expect(vm).to_not be_nil
+        vm_ids << cpi.create_vm(
+            'agent-007',
+            @stemcell_id,
+            vm_type,
+            network_spec,
+            [],
+            {'bosh' => {'groups' => %w[director, PKS]}}
+        )
 
-        expect(vm.cluster).to eq(@cluster_name)
+        vm_ids << cpi.create_vm(
+            'agent-007',
+            @stemcell_id,
+            vm_type,
+            network_spec,
+            [],
+            {'bosh' => {'groups' => %w[director, MySQL]}}
+        )
+
+        vm_ids << cpi.create_vm(
+            'agent-007',
+            @stemcell_id,
+            vm_type,
+            network_spec,
+            [],
+            {'bosh' => {'groups' => %w[director, PAS-23]}}
+        )
+
+        vm_ids.each do |vm_id|
+          expect(vm_id).to_not be_nil
+
+          vm = cpi.vm_provider.find(vm_id)
+          expect(vm).to_not be_nil
+
+          #expect(vm.cluster).to eq(@cluster_name)
+        end
+        require 'pry-byebug'
+        binding.pry
       ensure
-        delete_vm(cpi, vm_id)
+        vm_ids.each do |vm_id|
+          delete_vm(cpi, vm_id)
+        end
       end
     end
   end

--- a/src/vsphere_cpi/spec/integration/disk_reattachment_spec.rb
+++ b/src/vsphere_cpi/spec/integration/disk_reattachment_spec.rb
@@ -49,6 +49,30 @@ describe 're-attaching a persistent disk' do
       expect(disk_id).to_not be_nil
 
       @cpi.attach_disk(vm_id, disk_id)
+
+      require 'pry-byebug'
+      binding.pry
+
+      vm_id = @cpi.create_vm(
+          'agent-007',
+          @stemcell_id,
+          vm_type,
+          get_network_spec,
+          [],
+          {'key' => 'value'}
+      )
+
+      expect(vm_id).to_not be_nil
+      expect(@cpi.has_vm?(vm_id)).to be(true)
+
+      disk_id = @cpi.create_disk(2048, {}, vm_id)
+      expect(disk_id).to_not be_nil
+
+      @cpi.attach_disk(vm_id, disk_id)
+
+      require 'pry-byebug'
+      binding.pry
+
       @cpi.detach_disk(vm_id, disk_id)
       @cpi.attach_disk(vm_id, disk_id)
       @cpi.detach_disk(vm_id, disk_id)

--- a/src/vsphere_cpi/spec/support/lifecycle_properties.rb
+++ b/src/vsphere_cpi/spec/support/lifecycle_properties.rb
@@ -82,12 +82,12 @@ module LifecycleProperties
         'template_folder' => fetch_property('BOSH_VSPHERE_CPI_TEMPLATE_FOLDER'),
         'disk_path' => fetch_property('BOSH_VSPHERE_CPI_DISK_PATH'),
         'datastore_pattern' => @default_datastore_pattern,
-        'persistent_datastore_pattern' => @default_datastore_pattern,
+        'persistent_datastore_pattern' => 'nfs0-1',#@default_datastore_pattern'',
         'allow_mixed_datastores' => true,
         'clusters' => [
           {
             @default_cluster => {
-              'resource_pool' => @default_resource_pool,
+              #'resource_pool' => @default_resource_pool,
             }
           }
         ]


### PR DESCRIPTION
# Description

This change creates deployment named folder in vSphere Inventory for each BOSH Deployment

Steps:

Create_VM
1. Capture bosh deployment name from environment groups passed in create vm
2. Take new lock
3. Create Folder
4. Clone VM
5. Add VM Folder Path in Custom Attr
5. Release Lock

Delete_VM
1. Get VM Folder Path from custom attr, Extract vm parent folder
2. Delete VM
3. Get lock (same as in create)
4. Delete folder if no vm present.
5. Release Lock


### Disadvantage
Mutex is needed to cleanly delete bosh deployment named inventory folder. As VMs are constantly getting created and deleted, CPI needs synchronization to be able to decide when to delete deployment folder.
As a result, cloning and delete operations in vSphere becomes single threaded for one deployment.