### PR TITLE
Add support for nested resource pool specification.

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/cluster.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/cluster.rb
@@ -32,13 +32,13 @@ module VSphereCloud
       # @param [ClusterConfig] config cluster configuration as specified by the
       #   operator.
       # @param [Hash] properties prefetched vSphere properties for the cluster.
-      def initialize(cluster_config, properties, client)
+      def initialize(cluster_config, properties, client, datacenter_name)
         @client = client
         @properties = properties
 
         @config = cluster_config
         @mob = properties[:obj]
-        @resource_pool = ResourcePool.new(@client, cluster_config, properties['resourcePool'])
+        @resource_pool = ResourcePool.new(@client, cluster_config, properties['resourcePool'], datacenter_name)
       end
 
       # @return [Integer] amount of free memory in the cluster

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/cluster_provider.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/cluster_provider.rb
@@ -9,7 +9,7 @@ module VSphereCloud
       end
 
       # TODO: Add tests for this
-      def find(name, config)
+      def find(name, config, datacenter_name)
         cluster_mob = cluster_mobs[name]
         raise "Can't find cluster '#{name}'" if cluster_mob.nil?
 
@@ -22,7 +22,8 @@ module VSphereCloud
         Cluster.new(
           config,
           cluster_properties,
-          @client
+          @client,
+          datacenter_name,
         )
       end
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/datacenter.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/datacenter.rb
@@ -75,7 +75,7 @@ module VSphereCloud
 
       def find_cluster(cluster_name)
         cluster_config = @clusters[cluster_name]
-        @cluster_provider.find(cluster_name, cluster_config)
+        @cluster_provider.find(cluster_name, cluster_config, self.name)
       end
 
       def find_datastore(datastore_name)

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/resource_pool.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/resource_pool.rb
@@ -11,10 +11,11 @@ module VSphereCloud
       # @param [Cluster] cluster parent cluster.
       # @param [Vim::ResourcePool] root_resource_pool cluster's root resource
       #   pool.
-      def initialize(client, cluster_config, root_resource_pool)
+      def initialize(client, cluster_config, root_resource_pool, datacenter_name)
         @cluster_config = cluster_config
         @root_resource_pool = root_resource_pool
         @client = client
+        @datacenter_name = datacenter_name
       end
 
       def name
@@ -27,12 +28,24 @@ module VSphereCloud
         if @cluster_config.resource_pool.nil?
           @mob = @root_resource_pool
         else
-          client = @client
-          @mob = client.cloud_searcher.get_managed_object(
-            Vim::ResourcePool,
-            :root => @root_resource_pool,
-            :name => @cluster_config.resource_pool)
-          logger.debug("Found requested resource pool: #{@mob}")
+          begin
+            resource_pool_path_suffix = @cluster_config.resource_pool
+            datacenter_cluster_path_prefix = "#{@datacenter_name}/host/#{@cluster_config.name}/Resources/"
+            full_inventory_path = datacenter_cluster_path_prefix + resource_pool_path_suffix
+            # Replace all multiple consecutive / with single /
+            full_inventory_path.gsub!(/\/+/, '/').chomp!('/')
+            @mob = @client.service_content.search_index.find_by_inventory_path(full_inventory_path)
+            raise "Could not find resource pool #{resource_pool_path_suffix} for inventory path #{full_inventory_path}" if @mob.nil?
+          rescue => e
+            logger.info("#{e} - #{e.backtrace.join("\n")}")
+            logger.info("Trying to find #{@cluster_config.resource_pool} through property collector")
+            @mob = @client.cloud_searcher.get_managed_object(
+                Vim::ResourcePool,
+                :root => @root_resource_pool,
+                :name => @cluster_config.resource_pool)
+            raise "Could not find resource pool #{@cluster_config.resource_pool}" if @mob.nil?
+            logger.debug("Found requested resource pool: #{@mob}")
+          end
         end
         @mob
       end

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
@@ -124,13 +124,11 @@ module VSphereCloud
     end
     
     def find_clusters(clusters_spec)
-      clusters = []
-      datacenter_name = vm_type.datacenter.name
-      clusters_spec.each do |cluster_spec|
-        cluster_config = ClusterConfig.new(cluster_spec.keys.first, cluster_spec.values.first)
-        clusters.push(@cluster_provider.find(cluster_spec.keys.first, cluster_config, datacenter_name))
+      clusters_spec.map do |cluster_spec|
+        ClusterConfig.new(cluster_spec.keys.first, cluster_spec.values.first)
+      end.map do |cluster_config|
+        @cluster_provider.find(cluster_config.name, cluster_config, vm_type.datacenter.name)
       end
-      clusters
     end
 
     def global_clusters

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
@@ -125,9 +125,10 @@ module VSphereCloud
     
     def find_clusters(clusters_spec)
       clusters = []
+      datacenter_name = vm_type.datacenter.name
       clusters_spec.each do |cluster_spec|
         cluster_config = ClusterConfig.new(cluster_spec.keys.first, cluster_spec.values.first)
-        clusters.push(@cluster_provider.find(cluster_spec.keys.first, cluster_config))
+        clusters.push(@cluster_provider.find(cluster_spec.keys.first, cluster_config, datacenter_name))
       end
       clusters
     end

--- a/src/vsphere_cpi/spec/support/lifecycle_helpers.rb
+++ b/src/vsphere_cpi/spec/support/lifecycle_helpers.rb
@@ -144,22 +144,20 @@ module LifecycleHelpers
   end
 
   def verify_resource_pool(cpi, cluster_name, resource_pool_name, env_var_name)
-    resource_pool_mob = nil
-    begin
-      resource_pool_path_suffix = resource_pool_name
-      datacenter_cluster_path_prefix = "#{cpi.datacenter.name}/host/#{cluster_name}/Resources/"
-      full_inventory_path = datacenter_cluster_path_prefix + resource_pool_path_suffix
-      resource_pool_mob = cpi.client.service_content.search_index.find_by_inventory_path(full_inventory_path)
-      raise "Could not find resource pool #{resource_pool_path_suffix} for inventory path #{full_inventory_path}" if resource_pool_mob.nil?
-    rescue => e
-      cpi.logger.info("#{e} - #{e.backtrace.join("\n")}")
-      cpi.logger.info("Trying to find #{resource_pool_name} through property collector")
-      cluster_mob = cpi.datacenter.find_cluster(cluster_name).mob
-      resource_pool_mob = cpi.client.cloud_searcher.get_managed_objects(
-          VimSdk::Vim::ResourcePool,
-          :root => cluster_mob,
-          :name => resource_pool_name).first
-    end
+    resource_pool_path_suffix = resource_pool_name
+    datacenter_cluster_path_prefix = "#{cpi.datacenter.name}/host/#{cluster_name}/Resources/"
+    full_inventory_path = datacenter_cluster_path_prefix + resource_pool_path_suffix
+    resource_pool_mob = cpi.client.service_content.search_index.find_by_inventory_path(full_inventory_path)
+    return resource_pool_mob unless resource_pool_mob.nil?
+
+    cpi.logger.info("Could not find resource pool #{resource_pool_path_suffix} for inventory path #{full_inventory_path}")
+    cpi.logger.info("Trying to find #{resource_pool_name} through property collector")
+    cluster_mob = cpi.datacenter.find_cluster(cluster_name).mob
+    resource_pool_mob = cpi.client.cloud_searcher.get_managed_objects(
+        VimSdk::Vim::ResourcePool,
+        :root => cluster_mob,
+        :name => resource_pool_name
+    ).first
     if resource_pool_mob.nil?
       fail "Invalid Environment variable '#{env_var_name}': Expected to find resource pool '#{resource_pool_name}' in cluster '#{cluster_name}'"
     end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/cluster_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/cluster_spec.rb
@@ -6,11 +6,12 @@ module VSphereCloud::Resources
       VSphereCloud::Resources::Cluster.new(
         cluster_config,
         properties,
-        client
+        client,
+        "fake-dc"
       )
     end
-
-    let(:datacenter) { instance_double('VSphereCloud::Resources::Datacenter') }
+    let(:datacenter_name) { 'fake-dc' }
+    let(:datacenter) { instance_double('VSphereCloud::Resources::Datacenter', name: datacenter_name) }
 
     let(:log_output) { StringIO.new("") }
     let(:client) { instance_double('VSphereCloud::VCenterClient', cloud_searcher: cloud_searcher) }
@@ -72,7 +73,7 @@ module VSphereCloud::Resources
 
     before do
       allow(ResourcePool).to receive(:new).with(
-        client, cluster_config, fake_resource_pool_mob
+        client, cluster_config, fake_resource_pool_mob, datacenter_name
       ).and_return(fake_resource_pool)
 
       allow(cloud_searcher).to receive(:get_properties).with(
@@ -489,7 +490,8 @@ module VSphereCloud::Resources
     describe '#resource_pool' do
       it 'returns a resource pool object backed by the resource pool in the cloud properties' do
         expect(cluster.resource_pool).to eq(fake_resource_pool)
-        expect(ResourcePool).to have_received(:new).with(client, cluster_config, fake_resource_pool_mob)
+        expect(ResourcePool).to have_received(:new).with(client, cluster_config, fake_resource_pool_mob,
+                                                         datacenter_name)
       end
     end
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/datacenter_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/datacenter_spec.rb
@@ -133,10 +133,10 @@ describe VSphereCloud::Resources::Datacenter, fake_logger: true do
     allow(Bosh::Clouds::Config).to receive(:uuid).and_return('fake-uuid')
 
     allow(cluster_provider).to receive(:find)
-      .with('first-cluster', cluster_config1)
+      .with('first-cluster', cluster_config1, datacenter_name)
       .and_return(first_cluster)
     allow(cluster_provider).to receive(:find)
-      .with('second-cluster', cluster_config2)
+      .with('second-cluster', cluster_config2, datacenter_name)
       .and_return(second_cluster)
   end
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/resource_pool_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/resource_pool_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
 describe VSphereCloud::Resources::ResourcePool, fake_logger: true do
-  subject { VSphereCloud::Resources::ResourcePool.new(fake_client, cluster_config, root_resource_pool_mob) }
+  subject { VSphereCloud::Resources::ResourcePool.new(fake_client, cluster_config, root_resource_pool_mob, datacenter_name) }
   let(:fake_client) { instance_double('VSphereCloud::VCenterClient', cloud_searcher: cloud_searcher) }
   let(:cloud_searcher) { instance_double('VSphereCloud::CloudSearcher') }
+  let(:datacenter_name) { 'fake-dc' }
   let(:cluster_config) do
     instance_double('VSphereCloud::ClusterConfig', name: 'fake-cluster-name', resource_pool: cluster_resource_pool)
   end
@@ -19,15 +20,46 @@ describe VSphereCloud::Resources::ResourcePool, fake_logger: true do
     end
 
     context 'when the cluster config provides a resource pool' do
-      let(:cluster_resource_pool) { 'cluster-resource-pool' }
-      it 'uses the cluster config resource pool' do
-        resource_pool_mob = instance_double('VimSdk::Vim::ResourcePool')
+      let(:resource_pool_mob) { instance_double('VimSdk::Vim::ResourcePool') }
+      context 'when CPI is able to locate resource pool with inventory path' do
+        let(:cluster_resource_pool) { 'cluster-resource-pool' }
+        before do
+          allow(fake_client).to receive_message_chain(:service_content, :search_index, :find_by_inventory_path)
+                                       .with("fake-dc/host/fake-cluster-name/Resources/#{cluster_resource_pool}")
+                                       .and_return(resource_pool_mob)
+        end
+        it 'uses the cluster config resource pool' do
+          expect(subject.mob).to eq(resource_pool_mob)
+        end
+      end
+      context 'when CPI is not able to locate resource pool with inventory path' do
+        let(:cluster_resource_pool) { 'cluster-resource-pool' }
+        let(:resource_pool_mob) { instance_double('VimSdk::Vim::ResourcePool') }
+        before do
+          expect(fake_client).to receive_message_chain(:service_content, :search_index, :find_by_inventory_path)
+                               .with("fake-dc/host/fake-cluster-name/Resources/#{cluster_resource_pool}")
+                               .and_return(nil)
+        end
+        it 'uses the property collector to fetch the resource pool' do
+          expect(cloud_searcher).to receive(:get_managed_object)
+                                       .with(VimSdk::Vim::ResourcePool, root: root_resource_pool_mob, name: cluster_resource_pool)
+                                       .and_return(resource_pool_mob).once
 
-        allow(cloud_searcher).to receive(:get_managed_object)
-                              .with(VimSdk::Vim::ResourcePool, root: root_resource_pool_mob, name: cluster_resource_pool)
-                              .and_return(resource_pool_mob)
-
-        expect(subject.mob).to eq(resource_pool_mob)
+          expect(subject.mob).to eq(resource_pool_mob)
+        end
+      end
+      context 'when provided resource pool name is malformed' do
+        context 'when provided resource pool path has extra /<s>' do
+          let(:cluster_config) do
+            instance_double('VSphereCloud::ClusterConfig', name: 'fake-cluster-name', resource_pool: '///////vcpi-rp///vcpi-sub-rp//')
+          end
+          it 'removes the extra slashes and then finds resource pool' do
+            expect(fake_client).to receive_message_chain(:service_content, :search_index, :find_by_inventory_path)
+                                        .with("fake-dc/host/fake-cluster-name/Resources/vcpi-rp/vcpi-sub-rp")
+                                        .and_return(resource_pool_mob)
+            expect(subject.mob).to eq(resource_pool_mob)
+          end
+        end
       end
     end
   end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_config_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_config_spec.rb
@@ -14,7 +14,7 @@ module VSphereCloud
         cluster_provider: cluster_provider
       )
     end
-    let(:datacenter) { double(name: 'fake_datacenter') }
+    let(:datacenter) { double(name: 'fake-dc') }
     let(:vm_type) { VmType.new(datacenter, cloud_properties)}
     let(:cluster_provider) { nil }
 
@@ -199,11 +199,12 @@ module VSphereCloud
       let(:global_clusters) { [fake_cluster] }
 
       context 'when multiple clusters are specified within vm_type' do
+        let(:datacenter_name) { 'fake-dc' }
         let(:cloud_properties) {
           {
             'datacenters' => [
               {
-                'name' => 'datacenter-1',
+                'name' => datacenter_name,
                 'clusters' => [
                   { 'fake-cluster-name' => {} },
                   { 'fake-cluster-name-2' => {} }
@@ -224,8 +225,8 @@ module VSphereCloud
         it 'returns the vm_type cluster' do
           expect(VSphereCloud::ClusterConfig).to receive(:new).with('fake-cluster-name', {}).and_return(cluster_config)
           expect(VSphereCloud::ClusterConfig).to receive(:new).with('fake-cluster-name-2', {}).and_return(cluster_config_2)
-          expect(cluster_provider).to receive(:find).with('fake-cluster-name', cluster_config).and_return(fake_cluster)
-          expect(cluster_provider).to receive(:find).with('fake-cluster-name-2', cluster_config_2).and_return(fake_cluster_2)
+          expect(cluster_provider).to receive(:find).with('fake-cluster-name', cluster_config, datacenter_name).and_return(fake_cluster)
+          expect(cluster_provider).to receive(:find).with('fake-cluster-name-2', cluster_config_2, datacenter_name).and_return(fake_cluster_2)
           cluster_placement = vm_config.cluster_placements
           expect(cluster_placement.take(10).size).to eql(2)
         end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_config_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_config_spec.rb
@@ -171,8 +171,8 @@ module VSphereCloud
     describe '#cluster_placements' do
       let(:datastore_mob) { instance_double('VimSdk::Vim::Datastore') }
       let(:cluster_provider) { instance_double(VSphereCloud::Resources::ClusterProvider) }
-      let(:cluster_config) { instance_double(VSphereCloud::ClusterConfig) }
-      let(:cluster_config_2) { instance_double(VSphereCloud::ClusterConfig) }
+      let(:cluster_config) { instance_double(VSphereCloud::ClusterConfig, name: 'fake-cluster-name') }
+      let(:cluster_config_2) { instance_double(VSphereCloud::ClusterConfig, name: 'fake-cluster-name-2') }
       let(:small_ds) { instance_double(VSphereCloud::Resources::Datastore, free_space: 1024, mob: datastore_mob, maintenance_mode?: false) }
       let(:large_ds) { instance_double(VSphereCloud::Resources::Datastore, free_space: 2048, mob: datastore_mob, maintenance_mode?: false) }
       let(:huge_ds) { instance_double(VSphereCloud::Resources::Datastore, free_space: 10240, mob: datastore_mob, maintenance_mode?: false) }


### PR DESCRIPTION
- Adds support for specifying a resource pool path under a cluster.
- Currently, only a single name is accepted for resource pool and in
cases where multiple nested resource pools have same names, CPI fails to
identify them correctly; often returning the first match.
- This change introduces finding resource pools by inventory path. It is
a supported method in vCenter's search index object and is expected to
be much faster than propoerty collector.
- The fully qualified name of a resource pool is expected to be of form
  "Datacenter/host/Cluster/Resources/<Resource-Pool-Path (Relative to
  Cluster)"
  The CPI expects user to provide just the "<Resource-Pool-Path
  (Relative to Cluster)"


[#163777434](https://www.pivotaltracker.com/story/show/163777434)

# Description

Allows admin/operator to specify resource pool path (relative to the parent cluster)

## Related PR and Issues
Fixes #11 

## Impacted Areas in Application
Should Improve resource pool search performance.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] New & Existing Unit Tests
- [x] New & Existing Integration tests