### PR TITLE
Add checks to detect IP Conflict better

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -322,7 +322,7 @@ module VSphereCloud
             cpi: self,
             datacenter: @datacenter,
             agent_env: @agent_env,
-            ip_conflict_detector: IPConflictDetector.new(@client),
+            ip_conflict_detector: IPConflictDetector.new(@client, @datacenter),
             default_disk_type: @config.vcenter_default_disk_type,
             enable_auto_anti_affinity_drs_rules: @config.vcenter_enable_auto_anti_affinity_drs_rules,
             stemcell: Stemcell.new(stemcell_cid),

--- a/src/vsphere_cpi/lib/cloud/vsphere/ip_conflict_detector.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/ip_conflict_detector.rb
@@ -4,8 +4,9 @@ module VSphereCloud
   class IPConflictDetector
     include Logger
 
-    def initialize(client)
+    def initialize(client, datacenter)
       @client = client
+      @datacenter = datacenter
     end
 
     def ensure_no_conflicts(networks)
@@ -34,16 +35,18 @@ module VSphereCloud
             next
           end
           logger.info("Found VM '#{vm.name}' with IP '#{ip}'. Checking if VM belongs to network '#{name}'...")
-
           vm.guest.net.each do |nic|
-            if nic.ip_address.include?(ip) && nic.network == name
-              logger.info("found conflicting vm: #{vm.name}, on network: #{name} with ip: #{ip}")
-              conflicts << {vm_name: vm.name, network_name: name, ip: ip}
+            unqualified_name = File.basename(name)
+            if nic.ip_address.include?(ip) && nic.network == unqualified_name
+              network_mob = @client.find_network(@datacenter, name)
+              if network_mob.vm.include?(vm)
+                logger.info("found conflicting vm: #{vm.name}, on network: #{name} with ip: #{ip}")
+                conflicts << {vm_name: vm.name, network_name: name, ip: ip}
+              end
             end
           end
         end
       end
-
       conflicts
     end
 

--- a/src/vsphere_cpi/spec/integration/ip_conflict_detection_spec.rb
+++ b/src/vsphere_cpi/spec/integration/ip_conflict_detection_spec.rb
@@ -2,10 +2,11 @@ require 'integration/spec_helper'
 
 describe 'ip conflict detection' do
 
+  let(:fixed_ip_address) { '169.254.3.33' }
   let(:network_spec) do
     {
       'static' => {
-        'ip' => "169.254.#{rand(1..254)}.#{rand(4..254)}",
+        'ip' => fixed_ip_address,
         'netmask' => '255.255.254.0',
         'cloud_properties' => {'name' => vlan},
         'default' => ['dns', 'gateway'],
@@ -15,8 +16,6 @@ describe 'ip conflict detection' do
     }
   end
 
-  let(:vlan) { @vlan }
-
   let(:vm_type) do
     {
       'ram' => 512,
@@ -25,7 +24,9 @@ describe 'ip conflict detection' do
     }
   end
 
-  describe 'avoiding the creation of vms with duplicate IP addresses' do
+  context 'when testing with just unqualified network name' do
+    let(:vlan) { @vlan }
+
     it 'raises an error in create_vm if the ip address is in use' do
       begin
         test_vm_id = @cpi.create_vm(
@@ -34,7 +35,7 @@ describe 'ip conflict detection' do
           vm_type,
           network_spec,
           [],
-          {'key' => 'value'}
+          {}
         )
 
         block_on_vmware_tools(@cpi, test_vm_id)
@@ -47,12 +48,121 @@ describe 'ip conflict detection' do
             vm_type,
             network_spec,
             [],
-            {'key' => 'value'}
+            {}
           )
         }.to raise_error /Detected IP conflicts with other VMs on the same networks/
       ensure
         delete_vm(@cpi, test_vm_id)
         delete_vm(@cpi, duplicate_ip_vm_id)
+      end
+    end
+  end
+
+  context 'when testing with fully qualified network names' do
+    context 'when a VM already exists on a different network with same unqualified name' do
+
+      let(:network_spec_1) do
+        {
+          'static' => {
+            'ip' => fixed_ip_address,
+            'netmask' => '255.255.254.0',
+            'cloud_properties' => {'name' => vlan_1},
+            'default' => ['dns', 'gateway'],
+            'dns' => ['169.254.1.2'],
+            'gateway' => '169.254.1.3'
+          }
+        }
+      end
+
+      let(:network_spec_2) do
+        {
+          'static' => {
+            'ip' => fixed_ip_address,
+            'netmask' => '255.255.254.0',
+            'cloud_properties' => {'name' => vlan_2},
+            'default' => ['dns', 'gateway'],
+            'dns' => ['169.254.1.2'],
+            'gateway' => '169.254.1.3'
+          }
+        }
+      end
+
+      let(:vlan_1) { ENV.fetch('BOSH_VSPHERE_CPI_FOLDER_PORTGROUP_ONE') }
+      let(:vlan_2) { ENV.fetch('BOSH_VSPHERE_CPI_FOLDER_PORTGROUP_TWO') }
+
+      before do
+        verify_vlan(@cpi, vlan_1, 'BOSH_VSPHERE_CPI_FOLDER_PORTGROUP_ONE')
+        verify_vlan(@cpi, vlan_2, 'BOSH_VSPHERE_CPI_FOLDER_PORTGROUP_TWO')
+      end
+
+      it 'should create the VM' do
+        begin
+          test_vm_id = @cpi.create_vm(
+            'agent-007',
+            @stemcell_id,
+            vm_type,
+            network_spec_1,
+            [],
+            {}
+          )
+
+          block_on_vmware_tools(@cpi, test_vm_id)
+
+          duplicate_ip_vm_id = nil
+          expect {
+            duplicate_ip_vm_id = @cpi.create_vm(
+              'agent-elba',
+              @stemcell_id,
+              vm_type,
+              network_spec_2,
+              [],
+              {}
+            )
+          }.to_not raise_error
+
+          expect(duplicate_ip_vm_id).to_not be_nil
+          block_on_vmware_tools(@cpi, duplicate_ip_vm_id)
+
+          test_vm = @cpi.vm_provider.find(test_vm_id)
+          duplicate_ip_vm = @cpi.vm_provider.find(duplicate_ip_vm_id)
+
+          expect(test_vm.mob.guest.ip_address).to eq(duplicate_ip_vm.mob.guest.ip_address)
+        ensure
+          delete_vm(@cpi, test_vm_id)
+          delete_vm(@cpi, duplicate_ip_vm_id)
+        end
+      end
+    end
+    context 'when the VM already exists on the same network with same unqualified name' do
+      let(:vlan) { ENV.fetch('BOSH_VSPHERE_CPI_PORTGROUP_FOLDER_STANDARD') }
+      it 'should raise an error' do
+        begin
+          test_vm_id = @cpi.create_vm(
+            'agent-007',
+            @stemcell_id,
+            vm_type,
+            network_spec,
+            [],
+            {}
+          )
+
+          block_on_vmware_tools(@cpi, test_vm_id)
+
+          duplicate_ip_vm_id = nil
+          expect {
+            duplicate_ip_vm_id = @cpi.create_vm(
+              'agent-elba',
+              @stemcell_id,
+              vm_type,
+              network_spec,
+              [],
+              {}
+            )
+          }.to raise_error /Detected IP conflicts with other VMs on the same networks/
+        ensure
+          delete_vm(@cpi, test_vm_id)
+          delete_vm(@cpi, duplicate_ip_vm_id)
+        end
       end
     end
   end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -446,8 +446,8 @@ module VSphereCloud
         allow(datacenter).to receive(:persistent_pattern).and_return(target_datastore_pattern)
         allow(datacenter).to receive(:find_disk).with(director_disk_cid).and_return(fake_disk)
         allow(VSphereCloud::DirectorDiskCID).to receive(:new).with(encoded_disk_cid).and_return(director_disk_cid)
-        allow(IPConflictDetector).to receive(:new).with(vcenter_client).and_return(ip_conflict_detector)
-        allow(IPConflictDetector).to receive(:new).with(vcenter_client).and_return(ip_conflict_detector)
+        allow(IPConflictDetector).to receive(:new).with(vcenter_client, datacenter).and_return(ip_conflict_detector)
+        allow(IPConflictDetector).to receive(:new).with(vcenter_client, datacenter).and_return(ip_conflict_detector)
         allow(DiskConfig).to receive(:new)
           .with(
             cid: fake_disk.cid,

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/ip_conflict_detector_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/ip_conflict_detector_spec.rb
@@ -2,19 +2,22 @@ require 'spec_helper'
 
 module VSphereCloud
   describe IPConflictDetector, fake_logger: true do
+    let(:network_one_name) { 'network_1' }
+    let(:network_two_name) { 'network_2' }
     let(:networks) do
       {
-        'network_1' => ['169.254.1.1'],
-        'network_2' => ['169.254.2.1', '169.254.3.1']
+        network_one_name => ['169.254.1.1'],
+        network_two_name => ['169.254.2.1', '169.254.3.1']
       }
     end
     let(:client) { instance_double(VSphereCloud::VCenterClient) }
+    let(:datacenter) { instance_double(VSphereCloud::Resources::Datacenter) }
 
     context 'when no existing VMs on a desired network report having the desired IP' do
       it 'does not detect a conflict with deployed VMs' do
         allow(client).to receive(:find_vm_by_ip).and_return(nil)
 
-        conflict_detector = IPConflictDetector.new(client)
+        conflict_detector = IPConflictDetector.new(client, datacenter)
         expect {
           conflict_detector.ensure_no_conflicts(networks)
         }.to_not raise_error
@@ -31,44 +34,74 @@ module VSphereCloud
       end
 
       context 'when a deployed VM has the desired IPs on the same network' do
-        let(:deployed_vm_nics) do
-          [
-            instance_double(
-              VimSdk::Vim::Vm::GuestInfo::NicInfo,
-              ip_address: ['169.254.1.1', 'fe80::250:56ff:fea9:793d'],
-              network: 'network_1'
-            ),
-            instance_double(
-              VimSdk::Vim::Vm::GuestInfo::NicInfo,
-              ip_address: ['169.254.2.1', 'fe80::250:56ff:fea9:793d'],
-              network: 'network_2'
-            ),
-            instance_double(
-              VimSdk::Vim::Vm::GuestInfo::NicInfo,
-              ip_address: ['169.254.3.1', 'fe80::250:56ff:fea9:793d'],
-              network: 'network_2'
-            )
-          ]
+        context 'when the passed network name is unqualified name of same network' do
+          let(:networks) do
+            { network_one_name => ['169.254.1.1'] }
+          end
+          let(:deployed_vm_nics) do
+            [
+                instance_double(
+                    VimSdk::Vim::Vm::GuestInfo::NicInfo,
+                    ip_address: ['169.254.1.1', 'fe80::250:56ff:fea9:793d'],
+                    network: network_one_name
+                ),
+            ]
+          end
+          let(:network_mob) { instance_double(VimSdk::Vim::Network, vm: [deployed_vm] ) }
+
+          context 'when find network returns the correct single network' do
+            it 'detects conflicts with deployed VMs' do
+              expect(client).to receive(:find_vm_by_ip).with('169.254.1.1').and_return(deployed_vm)
+              expect(client).to receive(:find_network).with(datacenter, network_one_name).and_return(network_mob)
+              conflict_detector =  IPConflictDetector.new(client, datacenter)
+              expect {conflict_detector.ensure_no_conflicts(networks)}.to raise_error(/Detected IP/)
+            end
+          end
+          context 'when find network raises multiple network found exception' do
+            it 'raises and passes on the exception' do
+              expect(client).to receive(:find_network).with(datacenter, network_one_name).and_raise("Multiple N/W Found")
+              expect(client).to receive(:find_vm_by_ip).with('169.254.1.1').and_return(deployed_vm)
+              conflict_detector = IPConflictDetector.new(client, datacenter)
+              expect { conflict_detector.ensure_no_conflicts(networks)}.to raise_error(/Multiple N\/W/)
+            end
+          end
         end
+        context 'when the passed network name is fully qualified name of same network' do
+          let(:networks) do
+            { network_one_name => ['169.254.1.1'] }
+          end
+          let(:network_one_name) { 'folder-1/switch-1/network_1' }
+          let(:deployed_vm_nics) do
+            [
+                instance_double(
+                    VimSdk::Vim::Vm::GuestInfo::NicInfo,
+                    ip_address: ['169.254.1.1', 'fe80::250:56ff:fea9:793d'],
+                    network: 'network_1'
+                )
+            ]
+          end
+          let(:network_mob) { instance_double(VimSdk::Vim::Network, vm: [deployed_vm] ) }
 
-        it 'detects conflicts with deployed VMs' do
-          allow(client).to receive(:find_vm_by_ip).with('169.254.1.1').and_return(deployed_vm)
-          allow(client).to receive(:find_vm_by_ip).with('169.254.2.1').and_return(deployed_vm)
-          allow(client).to receive(:find_vm_by_ip).with('169.254.3.1').and_return(deployed_vm)
-
-          conflict_detector = IPConflictDetector.new(client)
-          expect {
-            conflict_detector.ensure_no_conflicts(networks)
-          }.to raise_error do |error|
-            expect(error.message).to include(
-              "squatter-vm",
-              "network_1",
-              "169.254.1.1",
-              "network_2",
-              "169.254.2.1",
-              "network_2",
-              "169.254.3.1"
-            )
+          context 'when the network has that VM on it' do
+            it 'detects conflict' do
+              expect(client).to receive(:find_vm_by_ip).with('169.254.1.1').and_return(deployed_vm)
+              expect(client).to receive(:find_network).with(datacenter, network_one_name).and_return(network_mob)
+              conflict_detector = IPConflictDetector.new(client,datacenter)
+              expect do
+                conflict_detector.ensure_no_conflicts(networks)
+              end.to raise_error(/Detected IP conflicts/)
+            end
+          end
+          context 'when the network does not have that VM on it' do
+            let(:network_mob) { instance_double(VimSdk::Vim::Network, vm: [] ) }
+            it 'returns empty conflict list' do
+              expect(client).to receive(:find_network).with(datacenter, network_one_name).and_return(network_mob)
+              expect(client).to receive(:find_vm_by_ip).with('169.254.1.1').and_return(deployed_vm)
+              conflict_detector = IPConflictDetector.new(client,datacenter)
+              expect do
+                conflict_detector.ensure_no_conflicts(networks)
+              end.to_not raise_error
+            end
           end
         end
       end
@@ -91,7 +124,7 @@ module VSphereCloud
           allow(client).to receive(:find_vm_by_ip).with('169.254.1.1').and_return(deployed_vm)
           allow(client).to receive(:find_vm_by_ip).with('169.254.2.1').and_return(deployed_vm)
           allow(client).to receive(:find_vm_by_ip).with('169.254.3.1').and_return(deployed_vm)
-          conflict_detector = IPConflictDetector.new(client)
+          conflict_detector = IPConflictDetector.new(client, datacenter)
           expect {
             conflict_detector.ensure_no_conflicts(networks)
           }.to_not raise_error


### PR DESCRIPTION
# Description

To prevent ip conflict detector from wrongly detecting a conflict when two networks have same unqualified name but different qualified names.

For Instance, `vcpi-switch-1/vcpi-dvpg-1` is different from `vcpi-switch-2/vcpi-dvpg-1`

Before this change using the above switches to create two VMs with same IP will raise an IP conflict. 

## Impacted Areas in Application
IP Conflict detector

## Type of change
Non-Breaking

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Unit Test
Integration Test
