### PR TITLE
WIP:Make Host Group Vm Group Affinity rule configurable for `MUST` vs `SHOULD`

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/cluster_config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cluster_config.rb
@@ -1,6 +1,5 @@
 module VSphereCloud
   class ClusterConfig
-
     attr_reader :name
 
     def initialize(name, config_hash)
@@ -8,8 +7,21 @@ module VSphereCloud
       @config = config_hash
     end
 
-    def host_group; @config['host_group']; end
+    def host_group_name
+        @config.dig('host_group', 'name')
+    end
 
-    def resource_pool; @config['resource_pool']; end
+    # Returns default ype should if drs_rule is not specified.
+    def host_group_drs_rule
+      host_group_drs_rule = @config.dig('host_group', 'drs_rule')
+      unless host_group_drs_rule.nil?
+        return host_group_drs_rule
+      end
+      'SHOULD'
+    end
+
+    def resource_pool
+      @config['resource_pool']
+    end
   end
 end

--- a/src/vsphere_cpi/lib/cloud/vsphere/drs_rules/drs_rule.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/drs_rules/drs_rule.rb
@@ -32,14 +32,14 @@ module VSphereCloud
     # @param [Vim::VirtualMachine] vm
     # @param [String] vm_group_name
     # @param [String] host_group_name
-    def add_vm_host_affinity_rule(vm_group_name, host_group_name)
+    def add_vm_host_affinity_rule(vm_group_name, host_group_name, rule_type)
       DrsLock.new(DRS_LOCK_HOST_VM_GROUP).with_drs_lock do
         rule = find_rule
         # Do not create the rule if it already exists
         unless rule
           # No error is raised if given host group does not exist,
           # it still creates the rule
-          create_vm_host_affinity_rule(vm_group_name, host_group_name)
+          create_vm_host_affinity_rule(vm_group_name, host_group_name, rule_type)
         end
       end
     end
@@ -71,11 +71,15 @@ module VSphereCloud
       add_anti_affinity_rule(VimSdk::Vim::Option::ArrayUpdateSpec::Operation::EDIT, rule_key)
     end
 
-    def create_vm_host_affinity_rule(vm_group_name, host_group_name)
+    def create_vm_host_affinity_rule(vm_group_name, host_group_name, rule_type)
       vm_host_rule_info = VimSdk::Vim::Cluster::VmHostRuleInfo.new
       vm_host_rule_info.enabled = true
-      # This is a HARD AFFINITY rule.
-      vm_host_rule_info.mandatory = true
+      # Check Hard or Soft Affinity
+      if rule_type == VSphereCloud::Resources::Cluster::CLUSTER_VM_HOST_RULE_MUST
+        vm_host_rule_info.mandatory = true
+      else
+        vm_host_rule_info.mandatory =  false
+      end
       vm_host_rule_info.name = @rule_name
       vm_host_rule_info.vm_group_name = vm_group_name
       vm_host_rule_info.affine_host_group_name = host_group_name

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
@@ -128,7 +128,7 @@ module VSphereCloud
         host = nil
         # Before cloning we need to make sure the host is correctly picked up
         # from cluster's host group if provided.
-        unless cluster.host_group.nil?
+        if !cluster.host_group.nil? && cluster.host_group_drs_rule.strip.casecmp?('MUST') == true
           # placement_spec = VimSdk::Vim::Cluster::PlacementSpec.new
           # placement_spec.config_spec = config_spec
           # placement_spec.datastores = [datastore.mob]
@@ -196,7 +196,7 @@ module VSphereCloud
           # Add vm to VM Group present in vm_type
           add_vm_to_vm_group(vm_config.vm_type.vm_group, created_vm_mob, cluster)
 
-          if !cluster.host_group.nil?
+          unless cluster.host_group.nil?
             # Add vm to VMGroup listed in the cluster description
             add_vm_to_vm_group(cluster.vm_group, created_vm.mob, cluster)
             # Create VM/Host affinity rule
@@ -312,7 +312,7 @@ module VSphereCloud
         @client,
         cluster.mob
       )
-      drs_rule.add_vm_host_affinity_rule(cluster.vm_group, cluster.host_group)
+      drs_rule.add_vm_host_affinity_rule(cluster.vm_group, cluster.host_group, cluster.host_group_rule_type)
     end
 
     def apply_storage_policy(vm_config, vm)

--- a/src/vsphere_cpi/spec/integration/vm_host_rule_spec.rb
+++ b/src/vsphere_cpi/spec/integration/vm_host_rule_spec.rb
@@ -20,7 +20,10 @@ describe 'Host Groups in Cluster and VM Host Rules' do
           clusters: [
             {
               @cluster_name => {
-                host_group:  @first_host_group,
+                host_group:  {
+                    'name' => @first_host_group,
+                    'drs_rule' => 'MUST',
+                }
               }
             }
           ]
@@ -45,9 +48,13 @@ describe 'Host Groups in Cluster and VM Host Rules' do
       cpi.client.cloud_searcher.get_managed_object(
         VimSdk::Vim::ClusterComputeResource, name: @second_cluster_name)
     end
-    let(:first_host_vm_group_name) { @first_host_group+VSphereCloud::Resources::Cluster::CLUSTER_VM_GROUP_SUFFIX }
-    let(:second_host_vm_group_name) { @second_host_group+VSphereCloud::Resources::Cluster::CLUSTER_VM_GROUP_SUFFIX }
-    let(:third_host_vm_group_name) { @third_host_group+VSphereCloud::Resources::Cluster::CLUSTER_VM_GROUP_SUFFIX }
+    let(:vm_grp_sfx) { VSphereCloud::Resources::Cluster::CLUSTER_VM_GROUP_SUFFIX }
+    let(:first_host_vm_group_name) { @first_host_group + 'MUST' + vm_grp_sfx }
+    let(:second_host_vm_group_name) { @second_host_group + 'MUST' + vm_grp_sfx }
+    let(:third_host_vm_group_name) { @third_host_group + 'MUST' + vm_grp_sfx }
+    let(:first_host_should_vm_group_name) { @first_host_group + 'SHOULD' + vm_grp_sfx }
+    let(:second_host_should_vm_group_name) { @second_host_group + 'SHOULD' + vm_grp_sfx }
+    let(:third_host_should_vm_group_name) { @third_host_group + 'SHOULD' + vm_grp_sfx }
     let(:first_host_group_mob) { find_host_group_mob(@first_host_group) }
     let(:second_host_group_mob) { find_host_group_mob(@second_host_group) }
     let(:third_host_group_mob) { find_host_group_mob(@third_host_group, second_cluster_mob) }
@@ -147,6 +154,7 @@ describe 'Host Groups in Cluster and VM Host Rules' do
         end
       end
       context 'and multiple host groups are specified in same vSphere cluster' do
+        let(:drs_rule) { 'MUST' }
         let(:cpi) do
           VSphereCloud::Cloud.new(cpi_options)
         end
@@ -160,32 +168,52 @@ describe 'Host Groups in Cluster and VM Host Rules' do
               'clusters' => [
                 {
                   @cluster_name => {
-                    'host_group' =>  @second_host_group,
+                    'host_group' =>  {'name' => @second_host_group, 'drs_rule' => drs_rule}
                   },
                 },
                 {
                   @cluster_name => {
-                    'host_group' =>  @first_host_group,
+                    'host_group' =>  {'name' => @first_host_group, 'drs_rule' => drs_rule}
                   }
                 },
               ]
             }]
           }
         end
-        it 'creates VM and attach vm group host affinity rule' do
-          simple_vm_lifecycle(cpi, '', vm_type, get_network_spec) do |vm_id|
-            vm = cpi.vm_provider.find(vm_id)
-            expect(vm.cluster).to eq(@cluster_name)
-            # We expect VM to be created on first host group
-            # because first host group has two hosts and more memory.
-            expect(hosts_in_first_host_group).to include(vm.mob.runtime.host.name)
-            expect(get_count_vm_host_affinity_rules(cluster_mob)).to eq(1)
-            expect(find_vm_group_mob(@first_host_group).vm).to include(vm.mob)
-            vm_host_rule = get_vm_host_affinity_rule(cluster_mob)
-            expect(vm_host_rule.vm_group_name).to eq(first_host_vm_group_name)
-            expect(vm_host_rule.affine_host_group_name).to eq(@first_host_group)
+        context 'when the drs rule type is must' do
+          it 'creates VM and attach vm group host affinity rule' do
+            simple_vm_lifecycle(cpi, '', vm_type, get_network_spec) do |vm_id|
+              vm = cpi.vm_provider.find(vm_id)
+              expect(vm.cluster).to eq(@cluster_name)
+              # We expect VM to be created on first host group
+              # because first host group has two hosts and more memory.
+              expect(hosts_in_first_host_group).to include(vm.mob.runtime.host.name)
+              expect(get_count_vm_host_affinity_rules(cluster_mob)).to eq(1)
+              expect(find_vm_group_mob(@first_host_group).vm).to include(vm.mob)
+              vm_host_rule = get_vm_host_affinity_rule(cluster_mob, drs_rule)
+              expect(vm_host_rule.vm_group_name).to eq(first_host_vm_group_name)
+              expect(vm_host_rule.affine_host_group_name).to eq(@first_host_group)
+            end
+            expect(get_count_vm_host_affinity_rules(cluster_mob)).to eq(0)
           end
-          expect(get_count_vm_host_affinity_rules(cluster_mob)).to eq(0)
+        end
+        context 'when the drs rule type is should' do
+          let(:drs_rule) { 'SHOULD' }
+          it 'creates VM and attach vm group host affinity rule' do
+            simple_vm_lifecycle(cpi, '', vm_type, get_network_spec) do |vm_id|
+              vm = cpi.vm_provider.find(vm_id)
+              expect(vm.cluster).to eq(@cluster_name)
+              # We expect VM to be created on first host group
+              # because first host group has two hosts and more memory.
+              expect(hosts_in_first_host_group).to include(vm.mob.runtime.host.name)
+              expect(get_count_vm_host_affinity_rules(cluster_mob)).to eq(1)
+              expect(find_vm_group_mob(@first_host_group, rule: 'SHOULD').vm).to include(vm.mob)
+              vm_host_rule = get_vm_host_affinity_rule(cluster_mob)
+              expect(vm_host_rule.vm_group_name).to eq(first_host_should_vm_group_name)
+              expect(vm_host_rule.affine_host_group_name).to eq(@first_host_group)
+            end
+            expect(get_count_vm_host_affinity_rules(cluster_mob)).to eq(0)
+          end
         end
       end
     end
@@ -198,8 +226,8 @@ describe 'Host Groups in Cluster and VM Host Rules' do
               datastore_pattern: @datastore_shared_pattern,
               persistent_datastore_pattern: @datastore_shared_pattern,
               clusters: [
-                { @cluster_name => { host_group: @first_host_group } },
-                { @second_cluster_name => { host_group: @third_host_group } },
+                { @cluster_name => { host_group: {'name' => @first_host_group, 'drs_rule' => 'MUST'} } },
+                { @second_cluster_name => { host_group: {'name' => @third_host_group, 'drs_rule' => 'must'} } },
               ]
             }]
           )
@@ -219,9 +247,9 @@ describe 'Host Groups in Cluster and VM Host Rules' do
             expect(expected_host_group_mob.host.map(&:name)).to include(vm_host)
             vm_cluster_mob = vm.cluster == @cluster_name ? cluster_mob : second_cluster_mob
             expect(get_count_vm_host_affinity_rules(vm_cluster_mob)).to eq(1)
-            expect(find_vm_group_mob(expected_host_group_mob.name, vm_cluster_mob).vm).to include(vm.mob)
+            expect(find_vm_group_mob(expected_host_group_mob.name, clustermob: vm_cluster_mob).vm).to include(vm.mob)
             vm_host_rule = get_vm_host_affinity_rule(vm_cluster_mob)
-            expect(vm_host_rule.vm_group_name).to eq(expected_host_group_mob.name+VSphereCloud::Resources::Cluster::CLUSTER_VM_GROUP_SUFFIX)
+            expect(vm_host_rule.vm_group_name).to eq(expected_host_group_mob.name + 'MUST' + vm_grp_sfx)
             expect(vm_host_rule.affine_host_group_name).to eq(expected_host_group_mob.name)
           end
           expect(get_count_vm_host_affinity_rules(cluster_mob) +
@@ -252,9 +280,9 @@ describe 'Host Groups in Cluster and VM Host Rules' do
               expect(expected_host_group_mob.host.map(&:name)).to include(vm_host)
               vm_cluster_mob = vm.cluster == @cluster_name ? cluster_mob : second_cluster_mob
               expect(get_count_vm_host_affinity_rules(vm_cluster_mob)).to eq(1)
-              expect(find_vm_group_mob(expected_host_group_mob.name, vm_cluster_mob).vm).to include(vm.mob)
+              expect(find_vm_group_mob(expected_host_group_mob.name, clustermob: vm_cluster_mob).vm).to include(vm.mob)
               vm_host_rule = get_vm_host_affinity_rule(vm_cluster_mob)
-              expect(vm_host_rule.vm_group_name).to eq(expected_host_group_mob.name+VSphereCloud::Resources::Cluster::CLUSTER_VM_GROUP_SUFFIX)
+              expect(vm_host_rule.vm_group_name).to eq(expected_host_group_mob.name + 'MUST' + vm_grp_sfx)
               expect(vm_host_rule.affine_host_group_name).to eq(expected_host_group_mob.name)
             end
           ensure
@@ -280,9 +308,9 @@ describe 'Host Groups in Cluster and VM Host Rules' do
                 expect(expected_host_group_mob.host.map(&:name)).to include(vm_host)
                 vm_cluster_mob = vm.cluster == @cluster_name ? cluster_mob : second_cluster_mob
                 expect(get_count_vm_host_affinity_rules(vm_cluster_mob)).to eq(1)
-                expect(find_vm_group_mob(expected_host_group_mob.name, vm_cluster_mob).vm).to include(vm.mob)
+                expect(find_vm_group_mob(expected_host_group_mob.name, clustermob: vm_cluster_mob).vm).to include(vm.mob)
                 vm_host_rule = get_vm_host_affinity_rule(vm_cluster_mob)
-                expect(vm_host_rule.vm_group_name).to eq(expected_host_group_mob.name+VSphereCloud::Resources::Cluster::CLUSTER_VM_GROUP_SUFFIX)
+                expect(vm_host_rule.vm_group_name).to eq(expected_host_group_mob.name + 'MUST' + vm_grp_sfx)
                 expect(vm_host_rule.affine_host_group_name).to eq(expected_host_group_mob.name)
               end
             end
@@ -304,7 +332,7 @@ describe 'Host Groups in Cluster and VM Host Rules' do
               expect(third_host_group_mob.host.map(&:name)).to include(vm_host)
               expect(vm.cluster).to eq(@second_cluster_name)
               expect(get_count_vm_host_affinity_rules(second_cluster_mob)).to eq(1)
-              expect(find_vm_group_mob(@third_host_group, second_cluster_mob).vm).to include(vm.mob)
+              expect(find_vm_group_mob(@third_host_group, clustermob: second_cluster_mob).vm).to include(vm.mob)
               vm_host_rule = get_vm_host_affinity_rule(second_cluster_mob)
               expect(vm_host_rule.vm_group_name).to eq(third_host_vm_group_name)
               expect(vm_host_rule.affine_host_group_name).to eq(@third_host_group)
@@ -323,7 +351,7 @@ describe 'Host Groups in Cluster and VM Host Rules' do
                   expect(vm.cluster).to eq(@second_cluster_name)
                   vm_cluster_mob = second_cluster_mob
                   expect(get_count_vm_host_affinity_rules(vm_cluster_mob)).to eq(1)
-                  expect(find_vm_group_mob(@third_host_group, vm_cluster_mob).vm).to include(vm.mob)
+                  expect(find_vm_group_mob(@third_host_group, clustermob: vm_cluster_mob).vm).to include(vm.mob)
                   vm_host_rule = get_vm_host_affinity_rule(vm_cluster_mob)
                   expect(vm_host_rule.vm_group_name).to eq(third_host_vm_group_name)
                   expect(vm_host_rule.affine_host_group_name).to eq(@third_host_group)
@@ -342,7 +370,7 @@ describe 'Host Groups in Cluster and VM Host Rules' do
               'datastore_pattern' => @datastore_shared_pattern,
               'persistent_datastore_pattern' => @datastore_shared_pattern,
               clusters: [
-                { @cluster_name => { host_group: @second_host_group, } },
+                { @cluster_name => { host_group: {'name' => @second_host_group, 'drs_rule' => 'Must'} } },
                 { @second_cluster_name => { resource_pool: @second_cluster_resource_pool_name, } },
               ]
             }]
@@ -392,23 +420,31 @@ describe 'Host Groups in Cluster and VM Host Rules' do
 
   private
 
-  def find_vm_group_mob(host_group_name, clustermob=cluster_mob)
+  def find_vm_group_mob(host_group_name, clustermob: cluster_mob, rule: 'MUST')
     clustermob.configuration_ex.group.find do |group|
-      group.name == (host_group_name+VSphereCloud::Resources::Cluster::CLUSTER_VM_GROUP_SUFFIX)
+      group.name == host_group_name + rule + VSphereCloud::Resources::Cluster::CLUSTER_VM_GROUP_SUFFIX
     end
   end
 
-  def find_host_group_mob(host_group_name, clustermob=cluster_mob)
+  def find_host_group_mob(host_group_name, clustermob = cluster_mob)
     clustermob.configuration_ex.group.find do |group|
       group.name == host_group_name && group.is_a?(VimSdk::Vim::Cluster::HostGroup)
     end
   end
 
-  def get_vm_host_affinity_rule(cluster_mob)
-    # return ing the first as we do not expect more rules to be present while
+  def get_vm_host_affinity_rule(cluster_mob, name_hint = nil)
+    # returning the first as we do not expect more rules to be present while
     # this test is in progress.
-    cluster_mob.configuration_ex.rule.select do |rule_info|
+    # Additionally, use name hint if provided to filter matching rules
+    matching_rules = cluster_mob.configuration_ex.rule.select do |rule_info|
       rule_info.is_a?(VimSdk::Vim::Cluster::VmHostRuleInfo)
-    end.first
+    end
+    unless name_hint.nil?
+      matching_rules.select do |rule_info|
+        rule_info.name.include?(name_hint)
+      end
+    end
+    matching_rules.first
   end
+
 end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cluster_config_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cluster_config_spec.rb
@@ -41,8 +41,8 @@ module VSphereCloud
       end
       context 'when host group is not defined' do
         let(:config){ {'resource_pool' => 'fake-resource-pool'} }
-        it 'returns nil' do
-          expect(cluster_config.host_group_drs_rule).to be_nil
+        it "still returns the rule as default 'SHOULD'" do
+          expect(cluster_config.host_group_drs_rule).to eq('SHOULD')
         end
       end
     end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cluster_config_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cluster_config_spec.rb
@@ -7,7 +7,7 @@ module VSphereCloud
     let(:config) do
       {
         'resource_pool' => 'fake-resource-pool',
-        'host_group' => 'fake-host-group',
+        'host_group' => {'name' => 'fake-host-group', 'drs_rule' => 'MUST'},
       }
     end
 
@@ -23,9 +23,27 @@ module VSphereCloud
       end
     end
 
-    describe '#host_group' do
+    describe '#host_group_name' do
       it 'returns the host group name' do
-        expect(cluster_config.host_group).to eq('fake-host-group')
+        expect(cluster_config.host_group_name).to eq('fake-host-group')
+      end
+      context 'when host group is not defined' do
+        let(:config){ {'resource_pool' => 'fake-resource-pool'} }
+        it 'returns nil' do
+          expect(cluster_config.host_group_name).to be_nil
+        end
+      end
+    end
+
+    describe '#host_group_drs_rule' do
+      it 'returns the host group drs rule condition' do
+        expect(cluster_config.host_group_drs_rule).to eq('MUST')
+      end
+      context 'when host group is not defined' do
+        let(:config){ {'resource_pool' => 'fake-resource-pool'} }
+        it 'returns nil' do
+          expect(cluster_config.host_group_drs_rule).to be_nil
+        end
       end
     end
   end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/drs_rules/drs_rule_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/drs_rules/drs_rule_spec.rb
@@ -156,7 +156,7 @@ describe VSphereCloud::DrsRule, fake_logger: true do
     let(:configuration_ex) { double(:configuration_ex, rule: rules) }
     let(:rules) { [ double(:rule, name: 'fake-rule-name', key: rule_key) ] }
     let(:rule_key) { 33 }
-
+    let(:rule_type) { nil }
     before do
       allow(datacenter_cluster).to receive(:configuration_ex).and_return(configuration_ex)
       allow(datacenter_cluster).to receive(:reconfigure_ex).and_return(task)
@@ -167,26 +167,68 @@ describe VSphereCloud::DrsRule, fake_logger: true do
         expect(drs_lock).to receive(:with_drs_lock).and_yield.ordered
         expect(datacenter_cluster).to_not receive(:reconfigure_ex)
         expect(drs_rule).to_not receive(:create_vm_host_affinity_rule)
-        drs_rule.add_vm_host_affinity_rule(vm_group_name, host_group_name)
+        drs_rule.add_vm_host_affinity_rule(vm_group_name, host_group_name, rule_type)
       end
     end
     context 'when rule does not exist' do
       let(:rules) { [] }
-      it 'it creates DRS rule with DRS lock' do
-        with_lock do
-          expect(datacenter_cluster).to receive(:reconfigure_ex) do |config|
-            rule_spec = config.rules_spec.first
-            expect(rule_spec.operation).to eq('add')
-            rule_info = rule_spec.info
-            expect(rule_info).to be_an_instance_of(VimSdk::Vim::Cluster::VmHostRuleInfo)
-            expect(rule_info.name).to eq('fake-rule-name')
-            expect(rule_info.vm_group_name).to eq(vm_group_name)
-            expect(rule_info.affine_host_group_name).to eq(host_group_name)
-            expect(rule_info.enabled).to eq(true)
-            expect(rule_info.key).to eq(nil)
-
-          end.ordered.and_return(task)
-          drs_rule.add_vm_host_affinity_rule(vm_group_name, host_group_name)
+      context 'when the rule type is nil' do
+        it 'it creates optional DRS rule with DRS lock' do
+          with_lock do
+            expect(datacenter_cluster).to receive(:reconfigure_ex) do |config|
+              rule_spec = config.rules_spec.first
+              expect(rule_spec.operation).to eq('add')
+              rule_info = rule_spec.info
+              expect(rule_info).to be_an_instance_of(VimSdk::Vim::Cluster::VmHostRuleInfo)
+              expect(rule_info.name).to eq('fake-rule-name')
+              expect(rule_info.mandatory).to eq(false)
+              expect(rule_info.vm_group_name).to eq(vm_group_name)
+              expect(rule_info.affine_host_group_name).to eq(host_group_name)
+              expect(rule_info.enabled).to eq(true)
+              expect(rule_info.key).to eq(nil)
+            end.ordered.and_return(task)
+            drs_rule.add_vm_host_affinity_rule(vm_group_name, host_group_name, rule_type)
+          end
+        end
+      end
+      context 'when the rule type is MUST' do
+        let(:rule_type) { 'MUST' }
+        it 'it creates mandatory DRS rule with DRS lock' do
+          with_lock do
+            expect(datacenter_cluster).to receive(:reconfigure_ex) do |config|
+              rule_spec = config.rules_spec.first
+              expect(rule_spec.operation).to eq('add')
+              rule_info = rule_spec.info
+              expect(rule_info).to be_an_instance_of(VimSdk::Vim::Cluster::VmHostRuleInfo)
+              expect(rule_info.name).to eq('fake-rule-name')
+              expect(rule_info.mandatory).to eq(true)
+              expect(rule_info.vm_group_name).to eq(vm_group_name)
+              expect(rule_info.affine_host_group_name).to eq(host_group_name)
+              expect(rule_info.enabled).to eq(true)
+              expect(rule_info.key).to eq(nil)
+            end.ordered.and_return(task)
+            drs_rule.add_vm_host_affinity_rule(vm_group_name, host_group_name, rule_type)
+          end
+        end
+        context 'when the rule type is SHOULD' do
+          let(:rule_type) { 'muST' }
+          it 'it creates optional DRS rule with DRS lock' do
+            with_lock do
+              expect(datacenter_cluster).to receive(:reconfigure_ex) do |config|
+                rule_spec = config.rules_spec.first
+                expect(rule_spec.operation).to eq('add')
+                rule_info = rule_spec.info
+                expect(rule_info).to be_an_instance_of(VimSdk::Vim::Cluster::VmHostRuleInfo)
+                expect(rule_info.name).to eq('fake-rule-name')
+                expect(rule_info.mandatory).to eq(false)
+                expect(rule_info.vm_group_name).to eq(vm_group_name)
+                expect(rule_info.affine_host_group_name).to eq(host_group_name)
+                expect(rule_info.enabled).to eq(true)
+                expect(rule_info.key).to eq(nil)
+              end.ordered.and_return(task)
+              drs_rule.add_vm_host_affinity_rule(vm_group_name, host_group_name, rule_type)
+            end
+          end
         end
       end
     end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/cluster_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/cluster_spec.rb
@@ -23,7 +23,7 @@ module VSphereCloud::Resources
         name: 'fake-cluster-name',
         resource_pool: 'fake-resource-pool',
         host_group_name: nil,
-        host_group_drs_rule: nil,
+        host_group_drs_rule: 'SHOULD',
       )
     end
 
@@ -449,8 +449,8 @@ module VSphereCloud::Resources
       end
       describe '#host_group_drs_rule' do
         context 'when host group is not defined in config' do
-          it 'returns nil' do
-            expect(cluster.host_group_drs_rule).to be(nil)
+          it 'returns SHOULD' do
+            expect(cluster.host_group_drs_rule).to eq('SHOULD')
           end
         end
         context 'when host group drs rule is defined in config' do


### PR DESCRIPTION
## What?
- Host group is now a Hash containing two keys:
    - Name
    - DRS Rule Type : MUST or SHOULD (Value check is not enforced)

- Create a DRS rule based on host group spec in cluster definition

- The advised values for rule type are MUST or SHOULD.

- Any bad value will make the drs rule default to `should` or `optional`

- Only a string with value MUST in any case and any number of leading or
 trailing white space characters is considered a valid value to make
 rule mandatory.

- For the must and should rule that concern with single host group, two
 different rules are created with two different vm groups tied to
 respective rules.

---
## WIP
Integration Tests
