### PR TITLE
Add support for human readable names (ASCII only)

### DIFF
--- a/jobs/vsphere_cpi/spec
+++ b/jobs/vsphere_cpi/spec
@@ -36,6 +36,9 @@ properties:
     default: false
   vcenter.vm_storage_policy_name:
     description: Name of the storage Policy which is applied to a VM and its ephemeral disk.
+  vcenter.enable_human_readable_name:
+    description: Enables human readable names for BOSH VMs.
+    default: true
   vcenter.connection_options.ca_cert:
     description: All required custom CA certificates
     example:

--- a/jobs/vsphere_cpi/templates/cpi.json.erb
+++ b/jobs/vsphere_cpi/templates/cpi.json.erb
@@ -23,6 +23,7 @@
             "default_disk_type" => p('vcenter.default_disk_type'),
             "enable_auto_anti_affinity_drs_rules" => p('vcenter.enable_auto_anti_affinity_drs_rules'),
             "upgrade_hw_version" => p('vcenter.upgrade_hw_version'),
+            "enable_human_readable_name" => p('vcenter.enable_human_readable_name'),
             "http_logging" => p('vcenter.http_logging')
           }
         ],

--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -307,7 +307,12 @@ module VSphereCloud
             global_clusters: @datacenter.clusters,
             disk_configurations: disk_configs,
             storage_policy: policy_name,
+            enable_human_readable_name: config.human_readable_name_enabled?
           }
+
+          if config.human_readable_name_enabled?
+            manifest_params.update(human_readable_name_info: update_name_info_from_bosh_env(environment))
+          end
 
           vm_config = VmConfig.new(
             manifest_params: manifest_params,
@@ -871,6 +876,18 @@ module VSphereCloud
       )
       disk_configurations.push(ephemeral_disk_config)
       return disk_configurations, policy_name
+    end
+
+    # An alias to {VSphereCloud::Cloud}'s get name information from bosh environment method
+    # @param environment [Hash] the BOSH environment setting information
+    #  [Array<String>, nil] return a array with 2 strings inside if there are both instance group name and deployment name
+    #   or a nil otherwise
+    def update_name_info_from_bosh_env(environment)
+      return nil if environment.nil?
+      instance_group_name = environment.dig('bosh', 'groups', 2)
+      deployment_name = environment.dig('bosh', 'groups', 1)
+      return nil if instance_group_name.nil? || deployment_name.nil?
+      OpenStruct.new(inst_grp: instance_group_name, deployment: deployment_name)
     end
   end
 end

--- a/src/vsphere_cpi/lib/cloud/vsphere/config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/config.rb
@@ -163,6 +163,10 @@ module VSphereCloud
         !!vcenter_datacenter['use_sub_folder']
     end
 
+    def human_readable_name_enabled?
+      vcenter['enable_human_readable_name']
+    end
+
     def nsx_url
       vcenter['nsx']['address']
     end
@@ -235,6 +239,7 @@ module VSphereCloud
             optional('upgrade_hw_version') => bool,
             optional('vm_storage_policy_name') => String,
             optional('nsxt') => dict(String, String),
+            optional('enable_human_readable_name') => bool,
             'datacenters' => [{
               'name' => String,
               'vm_folder' => String,

--- a/src/vsphere_cpi/spec/integration/human_readable_names_spec.rb
+++ b/src/vsphere_cpi/spec/integration/human_readable_names_spec.rb
@@ -1,0 +1,122 @@
+require 'integration/spec_helper'
+
+describe 'enable human readable names' do
+  let(:vm_type) do
+    {
+        'ram' => 512,
+        'disk' => 2048,
+        'cpu' => 1,
+    }
+  end
+
+  let(:network_spec) do
+    {
+      'static' => {
+        'ip' => "169.254.#{rand(1..254)}.#{rand(4..254)}",
+        'netmask' => '255.255.254.0',
+        'cloud_properties' => {'name' => @vlan},
+        'default' => ['dns', 'gateway'],
+        'dns' => ['169.254.1.2'],
+        'gateway' => '169.254.1.3'
+      }
+    }
+  end
+
+  let(:human_readable_name_cpi) do
+    options = cpi_options({'enable_human_readable_name' => true})
+    VSphereCloud::Cloud.new(options)
+  end
+
+  let(:machine_name_cpi) do
+    options = cpi_options({'enable_human_readable_name' => false})
+    VSphereCloud::Cloud.new(options)
+  end
+
+  context 'when enable human readable names is set to false' do
+    let(:environment){ {'bosh' => { 'groups' => ['fake-director-name', 'fake-deployment-name', 'fake-instance-group-name'] } } }
+    it 'create vm with UUID based name' do
+      begin
+        test_vm_id = machine_name_cpi.create_vm(
+          'agent-007',
+          @stemcell_id,
+          vm_type,
+          network_spec,
+          [],
+          environment
+        )
+        expect(test_vm_id).to_not be_nil
+        expect(test_vm_id.size).to eq 39 # "vm_" + 36 digits UUID
+        expect(test_vm_id).to match /vm-.*/
+      ensure
+        delete_vm(machine_name_cpi, test_vm_id)
+      end
+    end
+  end
+
+  context 'when enable human readable names is set to true' do
+    context 'when instance group name and deployment name are in ASCII characters' do
+      context 'when both instance group name and deployment name are set' do
+        let(:environment){ {'bosh' => { 'groups' => ['fake-director-name', 'fake-deployment-name', 'fake-instance-group-name'] } } }
+        it 'create vm with human readable name' do
+          begin
+            test_vm_id = human_readable_name_cpi.create_vm(
+                'agent-007',
+                @stemcell_id,
+                vm_type,
+                network_spec,
+                [],
+                environment
+            )
+            expect(test_vm_id).to_not be_nil
+            expect(test_vm_id.size).to eq 58  # "fake-instance-group-name_fake-deployment-name_" + 12 digits suffix
+            expect(test_vm_id).to start_with('fake-instance-group-name_fake-deployment-name_')
+          ensure
+            delete_vm(human_readable_name_cpi, test_vm_id)
+          end
+        end
+      end
+
+      context 'when bosh environment metadata is not in correct format' do
+        let(:environment){ {'bosh' => { 'groups' => ['fake-director-name', 'fake-deployment-name'] } } }
+        it 'create vm with UUID based name' do
+          begin
+            test_vm_id = human_readable_name_cpi.create_vm(
+              'agent-007',
+              @stemcell_id,
+              vm_type,
+              network_spec,
+              [],
+              environment
+            )
+            expect(test_vm_id).to_not be_nil
+            expect(test_vm_id.size).to eq 39
+            expect(test_vm_id).to match /vm-.*/
+          ensure
+            delete_vm(human_readable_name_cpi, test_vm_id)
+          end
+        end
+      end
+    end
+
+    context 'when instance group name and deployment name contain non_ASCII characters' do
+      let(:environment){ {'bosh' => { 'groups' => ['fake-director-name', 'ÅÅÅÅ', 'αβ'] } } }
+      it 'create vm with human readable name' do
+        begin
+          test_vm_id = human_readable_name_cpi.create_vm(
+            'agent-007',
+            @stemcell_id,
+            vm_type,
+            network_spec,
+            [],
+            environment
+          )
+          expect(test_vm_id).to_not be_nil
+          expect(test_vm_id.size).to eq 39
+          expect(test_vm_id).to match /vm-.*/
+        ensure
+          delete_vm(human_readable_name_cpi, test_vm_id)
+        end
+      end
+    end
+  end
+end

--- a/src/vsphere_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/vsphere_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -23,6 +23,7 @@ describe 'cpi.json.erb' do
           'user' => 'vcenter-user',
           'password' => 'vcenter-password',
           'enable_auto_anti_affinity_drs_rules' => true,
+          'enable_human_readable_name' => true,
           'upgrade_hw_version' => true,
           'vm_storage_policy_name' => 'VM Storage Policy',
           'http_logging' => true,
@@ -94,6 +95,7 @@ describe 'cpi.json.erb' do
               'user' => 'vcenter-user',
               'default_disk_type' => 'preallocated',
               'enable_auto_anti_affinity_drs_rules' => true,
+              'enable_human_readable_name' => true,
               'upgrade_hw_version' => true,
               'http_logging' => true,
               'vm_storage_policy_name' => 'VM Storage Policy'

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -2187,11 +2187,11 @@ module VSphereCloud
             }
           }
         end
-        it "returns an array with 2 strings inside" do
+        it "returns an struct " do
           result = vsphere_cloud.send(:update_name_info_from_bosh_env, environment)
-          expect(result.size).to eq(2)
-          expect(result[0]).to eq('fake-instance-group-name')
-          expect(result[1]).to eq('fake-deployment-name')
+          expect(result).to_not be_nil
+          expect(result.inst_grp).to eq('fake-instance-group-name')
+          expect(result.deployment).to eq('fake-deployment-name')
         end
       end
     end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/config_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/config_spec.rb
@@ -50,6 +50,7 @@ module VSphereCloud
           'password' => password,
           'default_disk_type' => default_disk_type,
           'vm_storage_policy_name' => vm_storage_policy_name,
+          'enable_human_readable_name' => false,
           'datacenters' => datacenters,
           'nsx' => {
             'address' => nsx_url,
@@ -427,6 +428,22 @@ module VSphereCloud
 
         it 'returns true' do
           expect(config.datacenter_use_sub_folder).to eq(true)
+        end
+      end
+    end
+
+    describe '#human_readable_name_enabled?' do
+      context 'when it is set to false' do
+        let(:config_hash) { {'vcenters' => ['enable_human_readable_name' => false] } }
+        it 'returns value false from config' do
+          expect(config.human_readable_name_enabled?).to eq(false)
+        end
+      end
+
+      context 'when it is set to true' do
+        let(:config_hash) { {'vcenters' => ['enable_human_readable_name' => true] } }
+        it 'returns value true from config' do
+          expect(config.human_readable_name_enabled?).to eq(true)
         end
       end
     end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_config_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_config_spec.rb
@@ -75,7 +75,9 @@ module VSphereCloud
         context 'when human readable name enabled is set to true' do
           context 'when human readable name information contains ASCII characters only' do
             context 'when human readable name information has both instance group name and deployment name' do
-              let(:input){ { human_readable_name_info: ['fake-instance-group-name', 'fake-deployment-name'] } }
+
+
+              let(:input){ { human_readable_name_info: OpenStruct.new(inst_grp: 'fake-instance-group-name', deployment: 'fake-deployment-name') } }
               it 'returns a valid human readable name' do
                 allow(vm_config).to receive(:generate_human_readable_name).with('fake-instance-group-name', 'fake-deployment-name').and_return('fake-instance-group-name_fake-deployment-name_13197a1f437e')
                 allow(vm_config).to receive(:human_readable_name_enabled?).and_return(true)
@@ -94,7 +96,7 @@ module VSphereCloud
             end
           end
           context 'when human readable name info contains non-ASCII characters' do
-            let(:input){ { human_readable_name_info: ['fake-instance-group-αβ', 'fake-deployment-name'] } }
+            let(:input){ { human_readable_name_info: OpenStruct.new(inst_grp: 'fake-instance-group-αβ', deployment: 'fake-deployment-name') } }
             it 'returns a UUID based VM name' do
               allow(vm_config).to receive(:generate_human_readable_name).with('fake-instance-group-αβ', 'fake-deployment-name').and_return('fake-instance-group-αβ1_fake-deployment-name_13197a1f437e')
               allow(vm_config).to receive(:human_readable_name_enabled?).and_return(true)


### PR DESCRIPTION
- Enable human readable names for BOSH created VMs
- Add Unit Tests
- Add Integration Tests

[153524141]https://www.pivotaltracker.com/n/projects/2110693/stories/153524141

# Description

Add support to enable human readable names for BOSH created VMs.
Currently only support names with legal ASCII characters.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [ X] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit Test
- [X] Integration Test


