### PR TITLE
Set human readable names disabled by default

### DIFF
--- a/jobs/vsphere_cpi/spec
+++ b/jobs/vsphere_cpi/spec
@@ -38,7 +38,7 @@ properties:
     description: Name of the storage Policy which is applied to a VM and its ephemeral disk.
   vcenter.enable_human_readable_name:
     description: Enables human readable names for BOSH VMs.
-    default: true
+    default: false
   vcenter.connection_options.ca_cert:
     description: All required custom CA certificates
     example:

--- a/src/vsphere_cpi/spec/integration/human_readable_names_spec.rb
+++ b/src/vsphere_cpi/spec/integration/human_readable_names_spec.rb
@@ -88,14 +88,26 @@ RSpec.describe '#human readable names' do
     end
 
     context 'when bosh environment metadata is not in correct format' do
+      let(:human_readable_name_cpi) do
+        options = cpi_options( {'enable_human_readable_name' => true} )
+        VSphereCloud::Cloud.new(options)
+      end
       let(:environment){ {'bosh' => { 'groups' => ['fake-director-name', 'fake-deployment-name'] } } }
       it_behaves_like 'create vm with UUID based name'
     end
     context 'when instance group name and deployment name contain non_ASCII characters' do
+      let(:human_readable_name_cpi) do
+        options = cpi_options( {'enable_human_readable_name' => true} )
+        VSphereCloud::Cloud.new(options)
+      end
       let(:environment){ {'bosh' => { 'groups' => ['fake-director-name', 'ÅÅÅÅ', 'αβ'] } } }
       it_behaves_like 'create vm with UUID based name'
     end
     context 'when both instance group name and deployment name are set with ASCII characters only' do
+      let(:human_readable_name_cpi) do
+        options = cpi_options( {'enable_human_readable_name' => true} )
+        VSphereCloud::Cloud.new(options)
+      end
       let(:environment){ {'bosh' => { 'groups' => ['fake-director-name', 'fake-deployment-name', 'fake-instance-group-name'] } } }
       it_behaves_like 'create a vm with human readable name'
     end


### PR DESCRIPTION
# Description

Initially human readable names feature is enabled by default. Now we disabled the feature by default.

Please delete options that are not relevant.
- [X] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit Test
- [X] Integration Test

# Checklist:

- [X] My code follows the standard ruby style guide
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
