### PR TITLE
FIX: NSX-T client cert isn't actually sent at runtime

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_api_client_builder.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_api_client_builder.rb
@@ -14,6 +14,10 @@ module VSphereCloud
         configuration.verify_ssl = false
         configuration.verify_ssl_host = false
       end
+      if config.private_key
+        configuration.key_file = config.private_key
+        configuration.cert_file = config.certificate
+      end
       NSXT::ApiClient.new(configuration)
     end
   end


### PR DESCRIPTION
# Description

The NSX-T mTLS client cert authentication is broken at runtime as the NSXTAPIClientBuilder never properly passes the key pair in.   The unit & integration tests had manually created the ApiClient but nothing actually exercises the NSXTAPIClientBuilder which missed these properties in its constructor.

## Impacted Areas in Application
This will allow for supporting NSX_T with mTLS client cert auth.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I've not tested this beyond a unit test run of existing unit tests. This PR is fairly self-evident of the simple fix & missing four lines of code.  You can reject it for a more complete / tested fix if you'd like, I'm short on time but figured this would be easier than filing an issue.

# Checklist:

- [X] My code follows the standard ruby style guide
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes