### PR TITLE
Support Shared Nothing svMotion and VMware replication disk migration 

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -487,7 +487,13 @@ module VSphereCloud
         end
 
         # Delete env.iso and VM specific files managed by the director
-        @agent_env.clean_env(vm.mob) if vm.cdrom
+        if vm.cdrom 
+          begin
+            @agent_env.clean_env(vm.mob)
+          rescue => e
+            logger.info("Failed to clean env.iso, likely sVmotioned VM: #{e}")
+          end
+        end
 
         if @config.nsxt_enabled?
           # POLICY API
@@ -640,8 +646,12 @@ module VSphereCloud
         disk = vm.disk_by_cid(director_disk_cid.value)
         raise Bosh::Clouds::DiskNotAttached.new(true), "Disk '#{director_disk_cid.value}' is not attached to VM '#{vm_cid}'" if disk.nil?
 
-        vm.detach_disks([disk])
-        delete_disk_from_agent_env(vm, director_disk_cid)
+        vm.detach_disks([disk], @datacenter.disk_path)
+        begin
+          delete_disk_from_agent_env(vm, director_disk_cid)
+        rescue => e
+          logger.warn("Cannot delete disk from agent env: #{e}")
+        end
       end
     end
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/vcenter_client.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vcenter_client.rb
@@ -122,9 +122,10 @@ module VSphereCloud
           @service_content.file_manager.delete_file(path, datacenter_mob)
         end
       rescue => e
-        unless e.message =~ /File .* was not found/
+        unless e.message =~ /File .* was not found|Invalid datastore path/ 
           raise e
         end
+        logger.warn("Cannot delete file: #{e}")
       end
     end
 
@@ -137,9 +138,10 @@ module VSphereCloud
           )
         end
       rescue => e
-        unless e.message =~ /File .* was not found/
+        unless e.message =~ /File .* was not found|Invalid datastore path/ 
           raise e
         end
+        logger.warn("Cannot delete disk: #{e}")
       end
     end
 
@@ -417,7 +419,7 @@ module VSphereCloud
       return false if vm_disk_infos.empty?
 
       true
-    rescue VimSdk::SoapError, FileNotFoundException
+    rescue 
       false
     end
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -1849,6 +1849,7 @@ module VSphereCloud
         end
 
         before do
+          allow(datacenter).to receive(:disk_path).and_return("fake-disk-path")
           allow(cdrom).to receive_message_chain(:backing, :datastore, :name) { 'fake-datastore-name' }
           allow(vcenter_client).to receive(:get_cdrom_device).with(vm_mob).and_return(cdrom)
           allow(agent_env).to receive(:get_current_env).with(vm_mob, 'fake-datacenter').and_return(env)
@@ -1862,7 +1863,7 @@ module VSphereCloud
               vm_location,
               {'disks' => {'persistent' => {}}}
             )
-          expect(vm).to receive(:detach_disks).with([attached_disk])
+          expect(vm).to receive(:detach_disks).with([attached_disk], 'fake-disk-path')
           vsphere_cloud.detach_disk('vm-id', 'disk-cid')
         end
 
@@ -1873,7 +1874,7 @@ module VSphereCloud
 
           it 'does not update VM with new setting' do
             expect(agent_env).to_not receive(:set_env)
-            expect(vm).to receive(:detach_disks).with([attached_disk])
+            expect(vm).to receive(:detach_disks).with([attached_disk], 'fake-disk-path')
             vsphere_cloud.detach_disk('vm-id', 'disk-cid')
           end
         end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/vcenter_client_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/vcenter_client_spec.rb
@@ -122,9 +122,26 @@ module VSphereCloud
         end
       end
 
+
+      context 'when file manager raises "Invalid Datastore path" error' do
+        it 'does not raise error' do
+          expect(task_runner).to receive(:run) do |*args, &block|
+            expect(block.call).to eq(task)
+          end.and_raise(RuntimeError.new('Invalid datastore path some/path'))
+
+          expect(file_manager).to receive(:delete_file).
+              with('[some-datastore] some/path', datacenter).
+              and_return(task)
+
+          expect {
+            client.delete_path(datacenter, '[some-datastore] some/path')
+          }.to_not raise_error
+        end
+      end
+
       context 'when file manager raises other error' do
         it 'raises that error' do
-          error = RuntimeError.new('Invalid datastore path some/path')
+          error = RuntimeError.new('Other error some/path')
           expect(task_runner).to receive(:run) do |*args, &block|
             expect(block.call).to eq(task)
           end.and_raise(error)
@@ -177,9 +194,24 @@ module VSphereCloud
         end
       end
 
+
+      context 'when file manager raises "Invalid datastore path" error for the disk' do
+        it 'does not raise error' do
+          expect(task_runner).to receive(:run) do |*args, &block|
+            expect(block.call).to eq(vmdk_task)
+          end.and_raise('Invalid datastore path some/path')
+
+          expect(virtual_disk_manager).to receive(:delete_virtual_disk).
+              with('[some-datastore] some/path', datacenter).
+              and_return(vmdk_task)
+          # We expect deleting the disk will not raise an error, it will fail the test if it does
+          client.delete_disk(datacenter, '[some-datastore] some/path')
+        end
+      end
+
       context 'when file manager raises other error' do
         it 'raises that error' do
-          error = RuntimeError.new('Invalid datastore path some/path')
+          error = RuntimeError.new('Other error path some/path')
           expect(task_runner).to receive(:run) do |*args, &block|
             expect(block.call).to eq(vmdk_task)
           end.and_raise(error)


### PR DESCRIPTION
# Description
1. Suppresses some errors that occur when`env.iso`and `env.json` are missing at VM detach or delete time (where it doesn't really matter if they're gone at this point).   This occurs with svMotion where datastores can't be mounted across clusters (e.g. VSAN, VxFlexOS)

2. Suppresses errors that occur if an old datastore path is missing after a storage vMotion or vSphere replication / SRM.    This is common with VSAN.

3. Supports a new persistent disk migration scenario - the VMDK retains its file name but the VM it is attached to has lost its vApp property that caches the datastore disk path.  This occurs with VMware Replication / SRM, where the persistent VMDK will be moved into the VM folder but will keep its filename.   In svMotion, the VMDK is moved *and* renamed, but we retain the vApp property to where to rename it.

## Impacted Areas in Application
Persistent disks

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Unit tests only; integration test was with several live customers that used storage vmotion or vmware replication

**Test Configuration**:
* Environment Variables for Integration test: VxRail, VMware 6.7, VSAN replicated from older cluster / datastore; also VMware 7.0.x with Nutanix datastores

# Checklist:

- [x] My code follows the standard ruby style guide
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
