### PR TITLE
Support auth to NSX-T with VMware Identity Manager 

### DIFF
--- a/jobs/vsphere_cpi/spec
+++ b/jobs/vsphere_cpi/spec
@@ -63,6 +63,9 @@ properties:
     description: Username to connect to NSX-T manager
   vcenter.nsxt.password:
     description: Password to connect to NSX-T manager
+  vcenter.nsxt.remote_auth:
+    description: Set to true if NSX-T manager is using VMware Identity Manager
+    default: false
   vcenter.nsxt.auth_certificate:
     description: Certificate used for certificate-based authentication. Certificate-based authentication takes precedence over username/password if both specified
   vcenter.nsxt.auth_private_key:

--- a/jobs/vsphere_cpi/templates/cpi.json.erb
+++ b/jobs/vsphere_cpi/templates/cpi.json.erb
@@ -94,6 +94,9 @@
     if_p('vcenter.nsxt.password') do
      vcenter['nsxt']['password'] = p('vcenter.nsxt.password')
     end
+    if_p('vcenter.nsxt.remote_auth') do
+     vcenter['nsxt']['remote_auth'] = p('vcenter.nsxt.remote_auth')
+    end
 
     if_p('vcenter.nsxt.auth_certificate') do
       vcenter['nsxt']['certificate'] = '/var/vcap/jobs/vsphere_cpi/config/nsxt_auth_certificate.crt'

--- a/src/vsphere_cpi/lib/cloud/vsphere/config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/config.rb
@@ -1,5 +1,5 @@
 module VSphereCloud
-  class NSXTConfig < Struct.new(:host, :username, :password, :certificate, :private_key, :default_vif_type)
+  class NSXTConfig < Struct.new(:host, :username, :password, :remote_auth, :certificate, :private_key, :default_vif_type)
     def self.validate_schema(config)
       return true if config.nil?
 
@@ -14,7 +14,9 @@ module VSphereCloud
               'private_key' => String})
         else
           common_rules.merge!({'username' => String,
-                               'password' => String})
+                               'password' => String,
+                               optional('remote_auth') => bool
+                             })
         end
         common_rules
       end.validate(config)
@@ -189,6 +191,7 @@ module VSphereCloud
         vcenter['nsxt']['host'],
         vcenter['nsxt']['username'],
         vcenter['nsxt']['password'],
+        vcenter['nsxt']['remote_auth'],
         vcenter['nsxt']['certificate'],
         vcenter['nsxt']['private_key'],
         vcenter['nsxt']['default_vif_type']
@@ -238,7 +241,15 @@ module VSphereCloud
             optional('enable_auto_anti_affinity_drs_rules') => bool,
             optional('upgrade_hw_version') => bool,
             optional('vm_storage_policy_name') => String,
-            optional('nsxt') => dict(String, String),
+            optional('nsxt') => {
+              optional('host') => String,
+              optional('username') => String,
+              optional('password') => String,
+              optional('remote_auth') => bool,
+              optional('certificate') => String,
+              optional('private_key') => String,
+              optional('default_vif_type') => String
+            },
             optional('enable_human_readable_name') => bool,
             'datacenters' => [{
               'name' => String,

--- a/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_api_client_builder.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_api_client_builder.rb
@@ -5,6 +5,9 @@ module VSphereCloud
       configuration.host = config.host
       configuration.username = config.username
       configuration.password = config.password
+      if config.remote_auth != nil
+        configuration.remote_auth = config.remote_auth
+      end
       configuration.logger = logger
       configuration.client_side_validation = false
       if ENV['BOSH_NSXT_CA_CERT_FILE']

--- a/src/vsphere_cpi/lib/nsxt/nsxt_client/configuration.rb
+++ b/src/vsphere_cpi/lib/nsxt/nsxt_client/configuration.rb
@@ -49,6 +49,11 @@ module NSXT
     # @return [String]
     attr_accessor :password
 
+    # Set this to false if NSX-T is using VMware Identity Manager
+    #
+    # @return [true, false]
+    attr_accessor :remote_auth
+
     # Defines the access token (Bearer) used with OAuth2.
     attr_accessor :access_token
 
@@ -143,6 +148,7 @@ module NSXT
       @debugging = false
       @inject_format = false
       @force_ending_format = false
+      @remote_auth = false
       @logger = defined?(Rails) ? Rails.logger : Logger.new(STDOUT)
 
       yield(self) if block_given?
@@ -189,8 +195,12 @@ module NSXT
     end
 
     # Gets Basic Auth token string
-    def basic_auth_token
-      'Basic ' + ["#{username}:#{password}"].pack('m').delete("\r\n")
+    def nsxt_auth_token
+      if @remote_auth
+        'Remote ' + ["#{username}:#{password}"].pack('m').delete("\r\n")
+      else
+        'Basic ' + ["#{username}:#{password}"].pack('m').delete("\r\n")
+      end
     end
 
     # Returns Auth Settings hash for api client.
@@ -201,7 +211,7 @@ module NSXT
             type: 'basic',
             in: 'header',
             key: 'Authorization',
-            value: basic_auth_token
+            value: nsxt_auth_token
           },
       }
     end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/config_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/config_spec.rb
@@ -193,6 +193,25 @@ module VSphereCloud
         end
       end
 
+      context 'when a valid nsxt with remote auth is passed in config' do
+        before do
+          config_hash.merge! 'nsxt' => {
+            'host' => 'fake-host',
+            'username' => 'fake-username',
+            'password' => 'fake-password',
+            'remote_auth' => true,
+            'certificate' => nil,
+            'private_key' => nil
+          }
+        end
+
+        it 'returns value from config' do
+          expect do
+            config.validate
+          end.to_not raise_error
+        end
+      end
+
       context 'when a valid nsxt with cert auth is passed in config' do
         before do
           config_hash.merge! 'nsxt' => {

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/nsxt_auth.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/nsxt_auth.rb
@@ -1,0 +1,48 @@
+require 'digest'
+require 'spec_helper'
+
+module VSphereCloud
+  describe NSXTConfig do
+    subject(:nsxt_config) { VSphereCloud::NSXTConfig.new('fake-host', 'fake-username', 'fake-passowrd') }
+    let(:logger) { instance_double('Logger') }
+    before { allow(Bosh::Clouds::Config).to receive(:logger).and_return(logger) }
+
+    before(:each) do
+        @configuration = NSXT::Configuration.new
+        @configuration.host = nsxt_config.host
+        @configuration.username = nsxt_config.username
+        @configuration.password = nsxt_config.password
+        @configuration
+    end
+
+    context "remote_auth not set" do
+      before(:each) do
+        @configuration.remote_auth = nil
+      end
+
+      it 'should have Authorization header start with "Basic"' do
+        expect(@configuration.nsxt_auth_token).to start_with('Basic ')
+      end
+    end
+
+    context "remote_auth set to false" do
+      before(:each) do
+        @configuration.remote_auth = false
+      end
+
+      it 'should have Authorization header start with "Basic"' do
+        expect(@configuration.nsxt_auth_token).to start_with('Basic ')
+      end
+    end
+
+    context "remote_auth set to true" do
+      before(:each) do
+        @configuration.remote_auth = true
+      end
+
+      it 'should have Authorization header start with "Basic"' do
+        expect(@configuration.nsxt_auth_token).to start_with('Remote ')
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description

The CPI currently does not support log in via username/password with NSX-T manager which is integrated with VMware Identity Manager (vIDM).
This pull requests adds this support via the setting of the deployment property `vcenter.nsxt.remote_auth` to `true`

## Impacted Areas in Application

The authorization header would be set to `Remote` if the property `vcenter.nsxt.remote_auth` is set to `ture` or will default `false` and set the to header to `Basic`

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] *This change requires a documentation update*

## How Has This Been Tested?

- [x] config_spec.rb unit test updated to include context `when a valid nsxt with remote auth is passed in config`
- [x] nsxt_auth.rb unit test to ensure backwards compatibility of the Authorization header if the `remote_auth` property is `nil` or `false` 
- [x] nsxt_auth.rb unit test to ensure Authorization is set correctly when `remote_auth` property is `true`

Tested in lab environment against version 2.4 of VMware NSX-T and vSphere version 6.7

- [x] Ensure auth header remained unchanged if `remote_auth` not set in deployment manifest
- [x] Ensure login to NSX-T via vIDM when `remote_auth` set to true.

# Checklist:

- [x] My code follows the standard ruby style guide
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
