### PR TITLE
Docs: Add Host.Config.SystemManagement

### DIFF
--- a/docs/required_vcenter_privileges.md
+++ b/docs/required_vcenter_privileges.md
@@ -146,10 +146,14 @@ These privileges must be granted on any entities in a Datacenter the CPI will in
     <tr><td>Snapshot management > Rename snapshot</td><td>VirtualMachine.State.RenameSnapshot</td></tr>
     <tr><td>Snapshot management > Revert snapshot</td><td>VirtualMachine.State.RevertToSnapshot</td></tr>
     <tr>
-      <td rowspan="4">vApp</td>
+      <td rowspan="3">vApp</td>
     </tr>
     <tr><td>Import</td><td>VApp.Import</td></tr>
     <tr><td>vApp application configuration</td><td>VApp.ApplicationConfig</td></tr>
+    <tr>
+      <td rowspan="2">Host</td>
+    </tr>
+    <tr><td>Config > System Management</td><td>Host.Config.SystemManagement</td></tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
Change documentation to show Host.Config.SystemManagement permission required. This permission is needed uploading files to datastore through Host System.

# Description

Documentation change.

## Related PR and Issues
N/A

## Impacted Areas in Application
N/A
## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Environment Variables for Integration test: vSphere 6.7.0
* Hardware Requirements in ESXi:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the standard ruby style guide
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

This is only documentation change.