### PR TITLE
Uses volume UUIDs for ephemeral and persistent disk identification

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -676,12 +676,25 @@ module VSphereCloud
       network_env
     end
 
-    def generate_disk_env(system_disk, ephemeral_disk)
-      {
+    def generate_disk_env(system_disk, ephemeral_disk, vm_config)
+
+      # When disk.enableUUID is true on the vmx options, consistent volume IDs are requested, and we can use them
+      # to ensure the precise ephemeral volume is mounted.   This is mandatory for
+      # cases where multiple SCSI controllers are present on the VM, as is common with Kubernetes VMs.
+
+      if vm_config.vmx_options['disk.enableUUID'] == "1"
+        {
+          'system' => system_disk.unit_number.to_s,
+          'ephemeral' => { 'id' => ephemeral_disk.backing.uuid.downcase }, 
+          'persistent' => {}
+        }
+      else
+        {
         'system' => system_disk.unit_number.to_s,
         'ephemeral' => ephemeral_disk.unit_number.to_s,
         'persistent' => {}
-      }
+        }
+      end
     end
 
     def generate_agent_env(name, vm, agent_id, networking_env, disk_env)
@@ -835,7 +848,36 @@ module VSphereCloud
 
     def add_disk_to_agent_env(vm, director_disk_cid, device_unit_number)
       env = @agent_env.get_current_env(vm.mob, @datacenter.name)
+
       env['disks']['persistent'][director_disk_cid.raw] = device_unit_number.to_s
+
+      # For VMs with multiple SCSI controllers, as is common in Kubernetes workers, 
+      # it is mandatory that disk.enableUUID is set in the VMX options / extra config of the VM to ensure 
+      # that disk mounting can be performed unambigously.   This is typically set as part of a VM extension.
+      # Using the relative device unit number (see above), which is the traditional vSphere CPI disk identifier, 
+      # only presumes a single SCSI controller.   The BOSH agent however does not distinguish SCSI controllers using
+      # this method of volume identification, which can lead to ambiguous mounts, and thus failed agent bootstraps or data loss.
+      # The BOSH agent already supports volume UUID identification, which is used below for unambiguous
+      # BOSH disk association.   
+
+      for options in vm.extra_config
+        if options.key == 'disk.enableUUID'
+          if options.value == "TRUE"
+            # We have to query the VIM API to learn the freshly attached disk UUID.   We must also pick the specific
+            # BOSH-managed independent persistent disk and avoid any non-BOSH peristent disks.  Also due to Linux
+            # filsystem case-sensitivity, ensure that the UUID is downcased as VIM returns it upper case.
+            disk = vm.disk_by_cid(director_disk_cid.value)
+            uuid = disk.backing.uuid.downcase
+            logger.info("adding disk to env, disk.enableUUID is TRUE, using volume uuid #{uuid} for mounting")
+            env['disks']['persistent'][director_disk_cid.raw] = {"id" => uuid}
+            break
+          else
+            logger.info("adding disk to env, disk.enableUUID is FALSE, using relative device number #{device_unit_number.to_s} for mounting")
+            break
+          end         
+        end        
+      end
+
       location = { datacenter: @datacenter.name, datastore: get_vm_env_datastore(vm), vm: vm.cid }
       @agent_env.set_env(vm.mob, location, env)
     end

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
@@ -211,6 +211,10 @@ module VSphereCloud
         properties['runtime.powerState']
       end
 
+      def extra_config
+        properties['config.extraConfig'] 
+      end
+
       def has_persistent_disk_property_mismatch?(disk)
         found_property = get_vapp_property_by_key(disk.key)
         return false if found_property.nil? || !verify_persistent_disk_property?(found_property)
@@ -366,8 +370,8 @@ module VSphereCloud
         @properties ||= cloud_searcher.get_properties(
           @mob,
           Vim::VirtualMachine,
-          ['runtime.powerState', 'runtime.question', 'config.hardware.device', 'name', 'runtime', 'resourcePool'],
-          ensure: ['config.hardware.device', 'runtime']
+          ['runtime.powerState', 'runtime.question', 'config.hardware.device', 'name', 'runtime', 'resourcePool', 'config.extraConfig'],
+          ensure: ['config.hardware.device', 'runtime', 'config.extraConfig']
         )
       end
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
@@ -178,7 +178,7 @@ module VSphereCloud
         # Set agent env settings
         begin
           network_env = @cpi.generate_network_env(created_vm.devices, vm_config.networks_spec, dvs_index)
-          disk_env = @cpi.generate_disk_env(created_vm.system_disk, ephemeral_disk_config.device)
+          disk_env = @cpi.generate_disk_env(created_vm.system_disk, created_vm.ephemeral_disk, vm_config)
           env = @cpi.generate_agent_env(vm_config.name, created_vm.mob, vm_config.agent_id, network_env, disk_env)
           env['env'] = vm_config.agent_env
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -1390,10 +1390,10 @@ module VSphereCloud
           allow(vm).to receive(:accessible_datastores).and_return('datastore-with-disk' => datastore_with_disk)
         end
 
-        it 'attaches the existing persistent disk' do
+        it 'attaches the existing persistent disk without uuid' do
           expect(datacenter).to receive(:find_disk).with(director_disk_cid, vm).and_return(disk)
           expect(VSphereCloud::DirectorDiskCID).to receive(:new).with('disk-cid').and_return(director_disk_cid)
-
+          expect(vm).to receive(:extra_config).and_return([OpenStruct.new(key: 'some-key', value: 'some-value')])
           expect(vm).to receive(:attach_disk) do |disk|
             expect(disk.cid).to eq('disk-cid')
             OpenStruct.new(device: OpenStruct.new(unit_number: 'some-unit-number'))
@@ -1406,7 +1406,30 @@ module VSphereCloud
           vsphere_cloud.attach_disk('fake-vm-cid', 'disk-cid')
         end
 
-        it 'attaches the existing persistent disk with encoded metadata' do
+        it 'attaches the existing persistent disk with uuid' do
+          expect(datacenter).to receive(:find_disk).with(director_disk_cid, vm).and_return(disk)
+          expect(VSphereCloud::DirectorDiskCID).to receive(:new).with('disk-cid').and_return(director_disk_cid)
+          
+          expect(vm).to receive(:attach_disk) do |disk|
+            expect(disk.cid).to eq('disk-cid')
+            OpenStruct.new(device: OpenStruct.new(backing: OpenStruct.new(uuid: 'SOME-UUID')))
+          end
+          expect(vm).to receive(:extra_config).and_return([OpenStruct.new(key: 'some-key', value: 'some-value'), OpenStruct.new(key: 'disk.enableUUID', value: 'TRUE')])
+
+          expect(vm).to receive(:disk_by_cid) do |disk_cid| 
+            expect(disk_cid).to eq('disk-cid')
+            OpenStruct.new(backing: OpenStruct.new(uuid: 'SOME-UUID'))
+          end 
+          
+          expect(agent_env).to receive(:set_env) do|env_vm, env_location, env|
+            expect(env_vm).to eq(vm_mob)
+            expect(env_location).to eq(vm_location)
+            expect(env['disks']['persistent']['disk-cid']).to eq({ 'id' => 'some-uuid'})
+          end
+          vsphere_cloud.attach_disk('fake-vm-cid', 'disk-cid')
+        end
+
+        it 'attaches the existing persistent disk with encoded metadata and without uuid' do
           metadata_hash = {
             target_datastore_pattern: '.*'
           }
@@ -1416,15 +1439,48 @@ module VSphereCloud
           director_disk_cid = VSphereCloud::DirectorDiskCID.new(disk_cid_with_metadata)
           expect(datacenter).to receive(:find_disk).with(director_disk_cid, vm).and_return(disk)
           expect(VSphereCloud::DirectorDiskCID).to receive(:new).with(disk_cid_with_metadata).and_return(director_disk_cid)
-
+          
           expect(vm).to receive(:attach_disk) do |disk|
             expect(disk.cid).to eq('disk-cid')
             OpenStruct.new(device: OpenStruct.new(unit_number: 'some-unit-number'))
           end
+          expect(vm).to receive(:extra_config).and_return([OpenStruct.new(key: 'some-key', value: 'some-value')])
+  
           expect(agent_env).to receive(:set_env) do |env_vm, env_location, env|
             expect(env_vm).to eq(vm_mob)
             expect(env_location).to eq(vm_location)
             expect(env['disks']['persistent'][disk_cid_with_metadata]).to eq('some-unit-number')
+          end
+
+          vsphere_cloud.attach_disk('fake-vm-cid', disk_cid_with_metadata)
+        end
+
+        it 'attaches the existing persistent disk with encoded metadata and with uuid' do
+          metadata_hash = {
+            target_datastore_pattern: '.*'
+          }
+          encoded_metadata = Base64.urlsafe_encode64(metadata_hash.to_json)
+          disk_cid_with_metadata = "disk-cid.#{encoded_metadata}"
+
+          director_disk_cid = VSphereCloud::DirectorDiskCID.new(disk_cid_with_metadata)
+          expect(datacenter).to receive(:find_disk).with(director_disk_cid, vm).and_return(disk)
+          expect(VSphereCloud::DirectorDiskCID).to receive(:new).with(disk_cid_with_metadata).and_return(director_disk_cid)
+          
+          expect(vm).to receive(:attach_disk) do |disk|
+            expect(disk.cid).to eq('disk-cid')
+            OpenStruct.new(device: OpenStruct.new(unit_number: 'some-unit-number', backing: OpenStruct.new(uuid: 'SOME-UUID')))
+          end
+          expect(vm).to receive(:extra_config).and_return([OpenStruct.new(key: 'some-key', value: 'some-value'), OpenStruct.new(key: 'disk.enableUUID', value: 'TRUE')])
+                  
+          expect(vm).to receive(:disk_by_cid) do |disk_cid| 
+            expect(disk_cid).to eq('disk-cid')
+            OpenStruct.new(backing: OpenStruct.new(uuid: 'SOME-UUID'))
+          end 
+
+          expect(agent_env).to receive(:set_env) do |env_vm, env_location, env|
+            expect(env_vm).to eq(vm_mob)
+            expect(env_location).to eq(vm_location)
+            expect(env['disks']['persistent'][disk_cid_with_metadata]).to eq({'id' => 'some-uuid'})
           end
 
           vsphere_cloud.attach_disk('fake-vm-cid', disk_cid_with_metadata)
@@ -1456,18 +1512,46 @@ module VSphereCloud
           expect(inaccessible_datastore).to receive(:accessible?).and_return(false)
         end
 
-        it 'moves the disk to an accessible datastore and attaches it' do
+        it 'moves the non-UUID disk to an accessible datastore and attaches it' do
           expect(datacenter).to receive(:find_disk).with(director_disk_cid, vm).and_return(disk)
           expect(VSphereCloud::DirectorDiskCID).to receive(:new).with('disk-cid').and_return(director_disk_cid)
           expect(datacenter).to receive(:move_disk_to_datastore).with(disk, datastore_without_disk)
             .and_return(moved_disk)
 
           expect(vm).to receive(:attach_disk).with(moved_disk)
-            .and_return(OpenStruct.new(device: OpenStruct.new(unit_number: 'some-unit-number')))
+            .and_return(OpenStruct.new(device: OpenStruct.new(unit_number: 'some-unit-number', backing: OpenStruct.new(uuid: 'some-uuid'))))
+          
+          expect(vm).to receive(:extra_config).and_return([OpenStruct.new(key: 'some-key', value: 'some-value')])
+          
           expect(agent_env).to receive(:set_env) do|env_vm, env_location, env|
             expect(env_vm).to eq(vm_mob)
             expect(env_location).to eq(vm_location)
             expect(env['disks']['persistent']['disk-cid']).to eq('some-unit-number')
+          end
+
+          vsphere_cloud.attach_disk('fake-vm-cid', 'disk-cid')
+        end
+
+        it 'moves the UUID disk to an accessible datastore and attaches it' do
+          expect(datacenter).to receive(:find_disk).with(director_disk_cid, vm).and_return(disk)
+          expect(VSphereCloud::DirectorDiskCID).to receive(:new).with('disk-cid').and_return(director_disk_cid)
+          expect(datacenter).to receive(:move_disk_to_datastore).with(disk, datastore_without_disk)
+            .and_return(moved_disk)
+
+          expect(vm).to receive(:attach_disk).with(moved_disk)
+            .and_return(OpenStruct.new(device: OpenStruct.new(unit_number: 'some-unit-number', backing: OpenStruct.new(uuid: 'SOME-UUID'))))
+          
+          expect(vm).to receive(:extra_config).and_return([OpenStruct.new(key: 'some-key', value: 'some-value'), OpenStruct.new(key: 'disk.enableUUID', value: 'TRUE')])
+          
+          expect(vm).to receive(:disk_by_cid) do |disk_cid| 
+            expect(disk_cid).to eq('disk-cid')
+            OpenStruct.new(backing: OpenStruct.new(uuid: 'SOME-UUID'))
+          end 
+
+          expect(agent_env).to receive(:set_env) do|env_vm, env_location, env|
+            expect(env_vm).to eq(vm_mob)
+            expect(env_location).to eq(vm_location)
+            expect(env['disks']['persistent']['disk-cid']).to eq({'id' => 'some-uuid'})
           end
 
           vsphere_cloud.attach_disk('fake-vm-cid', 'disk-cid')
@@ -1487,7 +1571,7 @@ module VSphereCloud
             )
         end
 
-        it 'moves the disk to a persistent datastore and attaches it' do
+        it 'moves the non-UUID disk to a persistent datastore and attaches it' do
           expect(datacenter).to receive(:find_disk).with(director_disk_cid, vm).and_return(disk)
           expect(VSphereCloud::DirectorDiskCID).to receive(:new).with('disk-cid').and_return(director_disk_cid)
 
@@ -1495,11 +1579,40 @@ module VSphereCloud
             .and_return(moved_disk)
 
           expect(vm).to receive(:attach_disk).with(moved_disk)
-            .and_return(OpenStruct.new(device: OpenStruct.new(unit_number: 'some-unit-number')))
+            .and_return(OpenStruct.new(device: OpenStruct.new(unit_number: 'some-unit-number', backing: OpenStruct.new(uuid: 'SOME-UUID'))))
+          
+          expect(vm).to receive(:extra_config).and_return([OpenStruct.new(key: 'some-key', value: 'some-value')])
+
           expect(agent_env).to receive(:set_env) do|env_vm, env_location, env|
             expect(env_vm).to eq(vm_mob)
             expect(env_location).to eq(vm_location)
             expect(env['disks']['persistent']['disk-cid']).to eq('some-unit-number')
+          end
+
+          vsphere_cloud.attach_disk('fake-vm-cid', 'disk-cid')
+        end
+
+        it 'moves the UUID disk to a persistent datastore and attaches it' do
+          expect(datacenter).to receive(:find_disk).with(director_disk_cid, vm).and_return(disk)
+          expect(VSphereCloud::DirectorDiskCID).to receive(:new).with('disk-cid').and_return(director_disk_cid)
+
+          expect(datacenter).to receive(:move_disk_to_datastore).with(disk, datastore_without_disk)
+            .and_return(moved_disk)
+
+          expect(vm).to receive(:attach_disk).with(moved_disk)
+            .and_return(OpenStruct.new(device: OpenStruct.new(unit_number: 'some-unit-number', backing: OpenStruct.new(uuid: 'SOME-UUID'))))
+          
+          expect(vm).to receive(:extra_config).and_return([OpenStruct.new(key: 'some-key', value: 'some-value'), OpenStruct.new(key: 'disk.enableUUID', value: 'TRUE')])
+
+          expect(vm).to receive(:disk_by_cid) do |disk_cid| 
+            expect(disk_cid).to eq('disk-cid')
+            OpenStruct.new(backing: OpenStruct.new(uuid: 'SOME-UUID'))
+          end 
+
+          expect(agent_env).to receive(:set_env) do|env_vm, env_location, env|
+            expect(env_vm).to eq(vm_mob)
+            expect(env_location).to eq(vm_location)
+            expect(env['disks']['persistent']['disk-cid']).to eq({'id' => 'some-uuid'})
           end
 
           vsphere_cloud.attach_disk('fake-vm-cid', 'disk-cid')
@@ -1546,8 +1659,11 @@ module VSphereCloud
           expect(datacenter).to receive(:move_disk_to_datastore).with(disk, target_datastore)
             .and_return(moved_disk)
 
+          allow(vm).to receive(:extra_config).and_return([OpenStruct.new(key: 'some-key', value: 'some-value'), OpenStruct.new(key: 'disk.enableUUID', value: 'TRUE')])
+          allow(vm).to receive(:disk_by_cid).and_return(OpenStruct.new(backing: OpenStruct.new(uuid: 'SOME-UUID')))
+            
           allow(vm).to receive(:attach_disk).with(moved_disk)
-            .and_return(OpenStruct.new(device: OpenStruct.new(unit_number: 'some-unit-number')))
+            .and_return(OpenStruct.new(device: OpenStruct.new(unit_number: 'some-unit-number', backing: OpenStruct.new(uuid: 'SOME-UUID'))))
           allow(agent_env).to receive(:set_env)
 
           vsphere_cloud.attach_disk('fake-vm-cid', encoded_disk_cid)

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/vm_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/vm_spec.rb
@@ -15,8 +15,8 @@ describe VSphereCloud::Resources::VM, fake_logger: true do
     allow(cloud_searcher).to receive(:get_properties).with(
       vm_mob,
       VimSdk::Vim::VirtualMachine,
-      ['runtime.powerState', 'runtime.question', 'config.hardware.device', 'name', 'runtime', 'resourcePool'],
-      ensure: ['config.hardware.device', 'runtime']
+      ['runtime.powerState', 'runtime.question', 'config.hardware.device', 'name', 'runtime', 'resourcePool', 'config.extraConfig'],
+      ensure: ['config.hardware.device', 'runtime', 'config.extraConfig']
     ).and_return(vm_properties)
 
     allow(client).to receive(:find_parent)
@@ -216,8 +216,8 @@ describe VSphereCloud::Resources::VM, fake_logger: true do
         allow(cloud_searcher).to receive(:get_properties).with(
           vm_mob,
           VimSdk::Vim::VirtualMachine,
-          ['runtime.powerState', 'runtime.question', 'config.hardware.device', 'name', 'runtime', 'resourcePool'],
-          ensure: ['config.hardware.device', 'runtime']
+          ['runtime.powerState', 'runtime.question', 'config.hardware.device', 'name', 'runtime', 'resourcePool', 'config.extraConfig'],
+          ensure: ['config.hardware.device', 'runtime', 'config.extraConfig']
         ).and_return({'runtime.question' => question, 'config.hardware.device' => vm_devices})
         allow(cloud_searcher).to receive(:get_property).with(
           vm_mob,


### PR DESCRIPTION
# Description
Traditionally the vSphere CPI used host-relative SCSI IDs for its disk identification to the bosh agent.
This does not work in a multi-SCSI controller environment such as Kubernetes, where disk devices may
be arbitrarily changed at reboot time (e.g. /dev/sda can't be assumed to be the root disk).

The existing behavior can lead to VMs locked up and/or Kubernetes PV data loss fter a VMware HA event, power outage/reboot, etc.

This fix detects if the VM has `disk.enableUUID` enabled in its extraConfig or `vmx_options`, which ensures
stable volume UUIDs between vSphere and the guest.  It will then use that UUID in its disk
identification to the BOSH agent, which already supports UUID matching.

## Related PR and Issues
Fixes PKS-341 (private JIRA)

## Impacted Areas in Application
List general components of the application that this PR will affect:

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?


- [X] Unit tests
- [X] Manual integration tests 

**Test Configuration**:
* Environment Variables for Integration test: 
* Hardware Requirements in ESXi: 6.5

# Checklist:

- [x] My code follows the standard ruby style guide
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
