### PR TITLE
Enable cert/key auth in NSXT

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_api_client_builder.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_api_client_builder.rb
@@ -17,6 +17,10 @@ module VSphereCloud
         configuration.verify_ssl = false
         configuration.verify_ssl_host = false
       end
+      if config.private_key
+        configuration.key_file = config.private_key
+        configuration.cert_file = config.certificate
+      end
       NSXT::ApiClient.new(configuration)
     end
   end


### PR DESCRIPTION
### Description

Add NSXT key/cert configuration while building NSXT API Client.