### PR TITLE
Enable Cert/Key based Auth for CPI_NSXT communication.

### DIFF
--- a/jobs/vsphere_cpi/spec
+++ b/jobs/vsphere_cpi/spec
@@ -6,9 +6,7 @@ templates:
   cpi.json.erb: config/cpi.json
   nsx_cacert.pem.erb: config/nsx_cacert.pem
   nsxt_cacert.pem.erb: config/nsxt_cacert.pem
-  nsxt_auth_certificate.crt.erb: config/nsxt_auth_certificate.crt
-  nsxt_auth_private_key.key.erb: config/nsxt_auth_private_key.key
-
+  
 packages:
 - iso9660wrap
 - ruby-2.4-r4

--- a/jobs/vsphere_cpi/templates/cpi.json.erb
+++ b/jobs/vsphere_cpi/templates/cpi.json.erb
@@ -99,10 +99,10 @@
     end
 
     if_p('vcenter.nsxt.auth_certificate') do
-      vcenter['nsxt']['certificate'] = '/var/vcap/jobs/vsphere_cpi/config/nsxt_auth_certificate.crt'
+      vcenter['nsxt']['auth_certificate'] = p('vcenter.nsxt.auth_certificate')
     end
     if_p('vcenter.nsxt.auth_private_key') do
-      vcenter['nsxt']['private_key'] = '/var/vcap/jobs/vsphere_cpi/config/nsxt_auth_private_key.key'
+      vcenter['nsxt']['auth_private_key'] = p('vcenter.nsxt.auth_private_key')
     end
 
     if_p('vcenter.nsxt.default_vif_type') do

--- a/jobs/vsphere_cpi/templates/nsxt_auth_certificate.crt.erb
+++ b/jobs/vsphere_cpi/templates/nsxt_auth_certificate.crt.erb
@@ -1,1 +1,0 @@
-<%= p('vcenter.nsxt.auth_certificate', '') %>

--- a/jobs/vsphere_cpi/templates/nsxt_auth_private_key.key.erb
+++ b/jobs/vsphere_cpi/templates/nsxt_auth_private_key.key.erb
@@ -1,1 +1,0 @@
-<%= p('vcenter.nsxt.auth_private_key', '') %>

--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -42,6 +42,24 @@ module VSphereCloud
       other_client.logout rescue nil
     end
 
+    def replace_certs_keys_with_temp_files(nsxt_config)
+      if nsxt_config.auth_private_key
+        # Configure private key and cert if provided.
+        @certificate_file = Tempfile.open('auth_certificate') do |f|
+          f << nsxt_config.auth_certificate; f
+        end
+
+        @auth_private_key_file = Tempfile.open('auth_private_key') do |f|
+          f << nsxt_config.auth_private_key; f
+        end
+
+        # Re write values to file paths rather than direct certs.
+        nsxt_config.auth_private_key = @auth_private_key_file.path
+        nsxt_config.auth_certificate = @certificate_file.path
+      end
+      nsxt_config
+    end
+
     def initialize(options)
       @config = Config.build(options)
 
@@ -91,7 +109,10 @@ module VSphereCloud
       @pbm = VSphereCloud::Pbm.new(pbm_api_uri: @config.pbm_api_uri, http_client: @http_client, vc_cookie: @client.soap_stub.vc_cookie)
 
       if @config.nsxt_enabled?
-        nsxt_client = NSXTApiClientBuilder::build_api_client(@config.nsxt, logger)
+
+        nsxt_config =  replace_certs_keys_with_temp_files(@config.nsxt)
+
+        nsxt_client = NSXTApiClientBuilder::build_api_client(nsxt_config, logger)
 
         # Setup NSX-T Provider
         @nsxt_provider = NSXTProvider.new(nsxt_client, @config.nsxt.default_vif_type)

--- a/src/vsphere_cpi/lib/cloud/vsphere/config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/config.rb
@@ -1,5 +1,5 @@
 module VSphereCloud
-  class NSXTConfig < Struct.new(:host, :username, :password, :remote_auth, :certificate, :private_key, :default_vif_type)
+  class NSXTConfig < Struct.new(:host, :username, :password, :remote_auth, :auth_certificate, :auth_private_key, :default_vif_type)
     def self.validate_schema(config)
       return true if config.nil?
 
@@ -10,8 +10,8 @@ module VSphereCloud
         if config['username'].nil?
           #using cert authentication
           common_rules.merge! ({
-              'certificate' => String,
-              'private_key' => String})
+              'auth_certificate' => String,
+              'auth_private_key' => String})
         else
           common_rules.merge!({'username' => String,
                                'password' => String,
@@ -192,8 +192,8 @@ module VSphereCloud
         vcenter['nsxt']['username'],
         vcenter['nsxt']['password'],
         vcenter['nsxt']['remote_auth'],
-        vcenter['nsxt']['certificate'],
-        vcenter['nsxt']['private_key'],
+        vcenter['nsxt']['auth_certificate'],
+        vcenter['nsxt']['auth_private_key'],
         vcenter['nsxt']['default_vif_type']
       )
     end
@@ -246,8 +246,8 @@ module VSphereCloud
               optional('username') => String,
               optional('password') => String,
               optional('remote_auth') => bool,
-              optional('certificate') => String,
-              optional('private_key') => String,
+              optional('auth_certificate') => String,
+              optional('auth_private_key') => String,
               optional('default_vif_type') => String
             },
             optional('enable_human_readable_name') => bool,

--- a/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_api_client_builder.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_api_client_builder.rb
@@ -3,23 +3,36 @@ module VSphereCloud
     def self.build_api_client(config, logger)
       configuration = NSXT::Configuration.new
       configuration.host = config.host
-      configuration.username = config.username
-      configuration.password = config.password
+
+      configuration.logger = logger
+      configuration.client_side_validation = false
+
+      # Configure auth key/cert or user/paswords
+      if config.auth_private_key
+        configuration.key_file = config.auth_private_key
+        configuration.cert_file = config.auth_certificate
+        # Are these required with key/cert pair?
+        # configuration.verify_ssl = false
+        # configuration.verify_ssl_host = false
+      else
+        configuration.username = config.username
+        configuration.password = config.password
+      end
+
+      # REMOTE AUTH for NSX-T vIDM Integration
       if config.remote_auth != nil
         configuration.remote_auth = config.remote_auth
       end
-      configuration.logger = logger
-      configuration.client_side_validation = false
+
+      # Root CA Cert
       if ENV['BOSH_NSXT_CA_CERT_FILE']
         configuration.ssl_ca_cert = ENV['BOSH_NSXT_CA_CERT_FILE']
       end
+
+      # SKIP SSL VALIDATION?
       if ENV['NSXT_SKIP_SSL_VERIFY']
         configuration.verify_ssl = false
         configuration.verify_ssl_host = false
-      end
-      if config.private_key
-        configuration.key_file = config.private_key
-        configuration.cert_file = config.certificate
       end
       NSXT::ApiClient.new(configuration)
     end

--- a/src/vsphere_cpi/spec/integration/nsxt_certificate_authentication_spec.rb
+++ b/src/vsphere_cpi/spec/integration/nsxt_certificate_authentication_spec.rb
@@ -108,7 +108,7 @@ describe 'NSXT certificate authentication', :nsxt_21 => true do
     @nsx_component_api.delete_certificate(cert_id)
   end
 
-  def attach_cert_to_principal(cert_id, pi_name = 'testprincipal', node_id = 'node-1')
+  def attach_cert_to_principal(cert_id, pi_name = 'testprincipal-3', node_id = 'node-5')
     pi = NSXT::PrincipalIdentity.new(name: pi_name, node_id: node_id,
                                      certificate_id: cert_id, permission_group: 'superusers')
     @nsx_component_api.register_principal_identity(pi).id

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -2036,6 +2036,7 @@ module VSphereCloud
       end
     end
 
+    # NOT NEEDED - FEATURE DISCONTINUED
     xdescribe '#create_network' do
       let(:network_definition) { {
                                  'range' => '192.168.111.0/24',
@@ -2092,6 +2093,7 @@ module VSphereCloud
       end
     end
 
+    # NOT NEEDED - FEATURE DISCONTINUED
     xdescribe '#delete_network' do
       let(:nsxt_provider) { instance_double(VSphereCloud::NSXTProvider) }
       let(:nsxt_client) { instance_double(NSXT::ApiClient) }
@@ -2203,5 +2205,32 @@ module VSphereCloud
       end
     end
 
+    describe '#replace_certs_keys_with_temp_files' do
+      let(:nsxt_config) do
+        VSphereCloud::NSXTConfig.new(
+          'host', 'user', 'password', 'true', 'cert', 'key', 'BARE_METAL'
+        )
+      end
+      it 'replaces certs and keys with their tempfile locations' do
+        subject.replace_certs_keys_with_temp_files(nsxt_config)
+        expect(nsxt_config.auth_private_key).to_not eq('key')
+        expect(File.read(nsxt_config.auth_private_key)).to eq('key')
+        expect(nsxt_config.auth_certificate).to_not eq('cert')
+        expect(File.read(nsxt_config.auth_certificate)).to eq('cert')
+      end
+
+      context 'when auth key is not provided' do
+        let(:nsxt_config) do
+          VSphereCloud::NSXTConfig.new(
+              'host', 'user', 'password', 'true', 'cert', nil, 'BARE_METAL'
+          )
+        end
+        it 'does not do anything on passed nsxt config' do
+          subject.replace_certs_keys_with_temp_files(nsxt_config)
+          expect(nsxt_config.auth_private_key).to be_nil
+          expect(nsxt_config.auth_certificate).to eq('cert')
+        end
+      end
+    end
   end
 end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/config_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/config_spec.rb
@@ -218,8 +218,8 @@ module VSphereCloud
               'host' => 'fake-host',
               'username' => nil,
               'password' => nil,
-              'certificate' => 'cert-path',
-              'private_key' => 'key-path'
+              'auth_certificate' => 'cert-path',
+              'auth_private_key' => 'key-path'
           }
         end
 


### PR DESCRIPTION
# Description

This change enables a user to specify cert/key for NSXT communication as documented here: https://bosh.io/docs/vsphere-cpi/#global

Although available since v51 , this did not work as the required changes were not present in `nsxt_api_client_builder`.

Another significant change is that CPI will not render these certs as files on director VM. Instead, it will store them as a temp file before passing that `file path` to the NSXT API Client.
The reason it is done via temporary file is that in the multi-cpi scenario rendering will not take place and config might be passed directly. In this case, we will need to create a temp file that can be consumed by `NSXTApiClient`

> Skipping a few unneeded unit tests.

## Type of change
Bug Fix

## How Has This Been Tested?
 - Integration test `nsxt_spec.rb` will use key/cert based NSXTAPIClient to carry out all nsxt operations. 
 - Unit tests added too.
