### PR TITLE
Uses volume UUIDs for ephemeral and persistent disk identification

### DIFF
--- a/ci/pipeline/main.yml.erb
+++ b/ci/pipeline/main.yml.erb
@@ -52,12 +52,6 @@ jobs:
         - put: environment
           resource: pool-6.5-NSXT21
           params: {acquire: true}
-        - task: extend-lease-6.5
-          file: source-ci/ci/tasks/extend-lease.yml
-          params:
-            DBCUSER: {{dbc_user}}
-            DBCHOST: {{dbc_host}}
-            DBC_SSH_KEY: {{dbc_key}}
           on_failure:
             put: pool-6.5-NSXT21
             params : {release: environment}
@@ -70,7 +64,7 @@ jobs:
         - get: source-ci
         - {get: cpi-release,              trigger: false, resource: bosh-cpi-artifacts, passed: [lock-bats]}
         - {get: environment,              trigger: true,  passed: [lock-bats], resource: pool-6.5-NSXT21}
-        - {get: bosh-release,             trigger: false, version: {version: "264.17.0"}, resource: old-bosh-release}
+        - {get: bosh-release,             trigger: false, resource: old-bosh-release}
         - {get: stemcell,                 trigger: false, version: {version: "3468.46"}, resource: stemcell}
         - {get: certification,            trigger: false}
         - {get: bosh-deployment,          trigger: false}

--- a/ci/pipeline/partition.yml.erb
+++ b/ci/pipeline/partition.yml.erb
@@ -9,12 +9,6 @@
       - put: environment
         resource: <%= e "pool-#{pool}" %>
         params: { acquire: true }
-      - task: extend-lease
-        file: source-ci/ci/tasks/extend-lease.yml
-        params:
-          DBCUSER: {{dbc_user}}
-          DBCHOST: {{dbc_host}}
-          DBC_SSH_KEY: {{dbc_key}}
         on_failure:
           put: <%= e "pool-#{pool}" %>
           params : { release: environment }

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
@@ -211,6 +211,10 @@ module VSphereCloud
         properties['runtime.powerState']
       end
 
+      def extra_config
+        properties['config.extraConfig'] 
+      end
+
       def has_persistent_disk_property_mismatch?(disk)
         found_property = get_vapp_property_by_key(disk.key)
         return false if found_property.nil? || !verify_persistent_disk_property?(found_property)
@@ -258,6 +262,12 @@ module VSphereCloud
         @client.add_persistent_disk_property_to_vm(self, disk)
         logger.debug('Finished adding persistent disk property to vm')
         return disk_config_spec
+      end
+
+      def disk_uuid_is_enabled?
+        extra_config.any? do |option|
+          option.key == 'disk.enableUUID' && option.value == "TRUE"
+        end
       end
 
       def detach_disks(virtual_disks)
@@ -366,8 +376,8 @@ module VSphereCloud
         @properties ||= cloud_searcher.get_properties(
           @mob,
           Vim::VirtualMachine,
-          ['runtime.powerState', 'runtime.question', 'config.hardware.device', 'name', 'runtime', 'resourcePool'],
-          ensure: ['config.hardware.device', 'runtime']
+          ['runtime.powerState', 'runtime.question', 'config.hardware.device', 'name', 'runtime', 'resourcePool', 'config.extraConfig'],
+          ensure: ['config.hardware.device', 'runtime', 'config.extraConfig']
         )
       end
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
@@ -178,7 +178,7 @@ module VSphereCloud
         # Set agent env settings
         begin
           network_env = @cpi.generate_network_env(created_vm.devices, vm_config.networks_spec, dvs_index)
-          disk_env = @cpi.generate_disk_env(created_vm.system_disk, ephemeral_disk_config.device)
+          disk_env = @cpi.generate_disk_env(created_vm.system_disk, created_vm.ephemeral_disk, vm_config)
           env = @cpi.generate_agent_env(vm_config.name, created_vm.mob, vm_config.agent_id, network_env, disk_env)
           env['env'] = vm_config.agent_env
 

--- a/src/vsphere_cpi/spec/integration/disk_reattachment_spec.rb
+++ b/src/vsphere_cpi/spec/integration/disk_reattachment_spec.rb
@@ -31,101 +31,215 @@ describe 're-attaching a persistent disk' do
     }
   end
 
-  it 're-attaches the disk without locking the cd-rom' do
-    begin
-      vm_id = @cpi.create_vm(
-        'agent-007',
-        @stemcell_id,
-        vm_type,
-        network_spec,
-        [],
-        {'key' => 'value'}
-      )
-
-      expect(vm_id).to_not be_nil
-      expect(@cpi.has_vm?(vm_id)).to be(true)
-
-      disk_id = @cpi.create_disk(2048, {}, vm_id)
-      expect(disk_id).to_not be_nil
-
-      @cpi.attach_disk(vm_id, disk_id)
-      @cpi.detach_disk(vm_id, disk_id)
-      @cpi.attach_disk(vm_id, disk_id)
-      @cpi.detach_disk(vm_id, disk_id)
-    ensure
-      delete_vm(@cpi, vm_id)
-      delete_disk(@cpi, disk_id)
-    end
-  end
-
-  context 'when there is no datastore matching pattern to move the disk to' do
-    let(:both_cluster_cpi_options) do
-      cpi_options(
-        datacenters: [{
-          persistent_datastore_pattern: @second_datastore_pattern,
-          clusters: [@cluster_name, @second_cluster_name],
-        }],
-      )
-    end
-    let(:both_cluster_cpi) { VSphereCloud::Cloud.new(both_cluster_cpi_options) }
-
-    let(:network_spec) do
-      {
-        'static' => {
-          'ip' => "169.254.#{rand(1..254)}.#{rand(4..254)}",
-          'netmask' => '255.255.254.0',
-          'cloud_properties' => {'name' => vlan},
-          'default' => ['dns', 'gateway'],
-          'dns' => ['169.254.1.2'],
-          'gateway' => '169.254.1.3'
-        }
-      }
-    end
-
-    let(:vlan) { @vlan }
-
+  context 'when vm_type has disk uuid enabled in vmx options' do
     let(:vm_type) do
       {
-        'ram' => 512,
-        'disk' => 2048,
-        'cpu' => 1,
-        'datastores' => [@datastore_pattern],
-        'datacenters' => [
-          {
-            'name' => @datacenter_name,
-            'clusters' => [
-              {
-                @cluster_name => {}
-              }
-            ]
+          'ram' => 512,
+          'disk' => 2048,
+          'cpu' => 1,
+          'vmx_options' => {
+              'disk.enableUUID' => 'TRUE'
           }
-        ]
       }
     end
-    it 'raises error ' do
+
+    it 're-attaches the disk without locking the cd-rom' do
       begin
         vm_id = @cpi.create_vm(
-          'agent-007',
-          @stemcell_id,
-          vm_type,
-          network_spec,
-          [],
-          {'key' => 'value'}
+            'agent-007',
+            @stemcell_id,
+            vm_type,
+            network_spec,
+            [],
+            {'key' => 'value'}
         )
 
         expect(vm_id).to_not be_nil
         expect(@cpi.has_vm?(vm_id)).to be(true)
 
-        disk_id = both_cluster_cpi.create_disk(2048, {datastores: @second_datastore_pattern})
+        disk_id = @cpi.create_disk(2048, {}, vm_id)
         expect(disk_id).to_not be_nil
 
-        expect do
-          both_cluster_cpi.attach_disk(vm_id, disk_id)
-        end.to raise_error(/Unable to attach disk to the VM/)
+        @cpi.attach_disk(vm_id, disk_id)
+        @cpi.detach_disk(vm_id, disk_id)
+        @cpi.attach_disk(vm_id, disk_id)
+        @cpi.detach_disk(vm_id, disk_id)
       ensure
         delete_vm(@cpi, vm_id)
-        delete_disk(both_cluster_cpi, disk_id)
+        delete_disk(@cpi, disk_id)
+      end
+    end
+
+    context 'when there is no datastore matching pattern to move the disk to' do
+      let(:both_cluster_cpi_options) do
+        cpi_options(
+            datacenters: [{
+                              persistent_datastore_pattern: @second_datastore_pattern,
+                              clusters: [@cluster_name, @second_cluster_name],
+                          }],
+            )
+      end
+      let(:both_cluster_cpi) { VSphereCloud::Cloud.new(both_cluster_cpi_options) }
+
+      let(:network_spec) do
+        {
+            'static' => {
+                'ip' => "169.254.#{rand(1..254)}.#{rand(4..254)}",
+                'netmask' => '255.255.254.0',
+                'cloud_properties' => {'name' => vlan},
+                'default' => ['dns', 'gateway'],
+                'dns' => ['169.254.1.2'],
+                'gateway' => '169.254.1.3'
+            }
+        }
+      end
+
+      let(:vlan) { @vlan }
+
+      let(:vm_type) do
+        {
+            'ram' => 512,
+            'disk' => 2048,
+            'cpu' => 1,
+            'datastores' => [@datastore_pattern],
+            'datacenters' => [
+                {
+                    'name' => @datacenter_name,
+                    'clusters' => [
+                        {
+                            @cluster_name => {}
+                        }
+                    ]
+                }
+            ]
+        }
+      end
+      it 'raises error ' do
+        begin
+          vm_id = @cpi.create_vm(
+              'agent-007',
+              @stemcell_id,
+              vm_type,
+              network_spec,
+              [],
+              {'key' => 'value'}
+          )
+
+          expect(vm_id).to_not be_nil
+          expect(@cpi.has_vm?(vm_id)).to be(true)
+
+          disk_id = both_cluster_cpi.create_disk(2048, {datastores: @second_datastore_pattern})
+          expect(disk_id).to_not be_nil
+
+          expect do
+            both_cluster_cpi.attach_disk(vm_id, disk_id)
+          end.to raise_error(/Unable to attach disk to the VM/)
+        ensure
+          delete_vm(@cpi, vm_id)
+          delete_disk(both_cluster_cpi, disk_id)
+        end
       end
     end
   end
+
+  context 'when vm_type has no disk uuid enabled' do
+    it 're-attaches the disk without locking the cd-rom' do
+      begin
+        vm_id = @cpi.create_vm(
+            'agent-007',
+            @stemcell_id,
+            vm_type,
+            network_spec,
+            [],
+            {'key' => 'value'}
+        )
+
+        expect(vm_id).to_not be_nil
+        expect(@cpi.has_vm?(vm_id)).to be(true)
+
+        disk_id = @cpi.create_disk(2048, {}, vm_id)
+        expect(disk_id).to_not be_nil
+
+        @cpi.attach_disk(vm_id, disk_id)
+        @cpi.detach_disk(vm_id, disk_id)
+        @cpi.attach_disk(vm_id, disk_id)
+        @cpi.detach_disk(vm_id, disk_id)
+      ensure
+        delete_vm(@cpi, vm_id)
+        delete_disk(@cpi, disk_id)
+      end
+    end
+
+    context 'when there is no datastore matching pattern to move the disk to' do
+      let(:both_cluster_cpi_options) do
+        cpi_options(
+            datacenters: [{
+                              persistent_datastore_pattern: @second_datastore_pattern,
+                              clusters: [@cluster_name, @second_cluster_name],
+                          }],
+            )
+      end
+      let(:both_cluster_cpi) { VSphereCloud::Cloud.new(both_cluster_cpi_options) }
+
+      let(:network_spec) do
+        {
+            'static' => {
+                'ip' => "169.254.#{rand(1..254)}.#{rand(4..254)}",
+                'netmask' => '255.255.254.0',
+                'cloud_properties' => {'name' => vlan},
+                'default' => ['dns', 'gateway'],
+                'dns' => ['169.254.1.2'],
+                'gateway' => '169.254.1.3'
+            }
+        }
+      end
+
+      let(:vlan) { @vlan }
+
+      let(:vm_type) do
+        {
+            'ram' => 512,
+            'disk' => 2048,
+            'cpu' => 1,
+            'datastores' => [@datastore_pattern],
+            'datacenters' => [
+                {
+                    'name' => @datacenter_name,
+                    'clusters' => [
+                        {
+                            @cluster_name => {}
+                        }
+                    ]
+                }
+            ]
+        }
+      end
+      it 'raises error ' do
+        begin
+          vm_id = @cpi.create_vm(
+              'agent-007',
+              @stemcell_id,
+              vm_type,
+              network_spec,
+              [],
+              {'key' => 'value'}
+          )
+
+          expect(vm_id).to_not be_nil
+          expect(@cpi.has_vm?(vm_id)).to be(true)
+
+          disk_id = both_cluster_cpi.create_disk(2048, {datastores: @second_datastore_pattern})
+          expect(disk_id).to_not be_nil
+
+          expect do
+            both_cluster_cpi.attach_disk(vm_id, disk_id)
+          end.to raise_error(/Unable to attach disk to the VM/)
+        ensure
+          delete_vm(@cpi, vm_id)
+          delete_disk(both_cluster_cpi, disk_id)
+        end
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
# Description
Traditionally the vSphere CPI used host-relative SCSI IDs for its disk identification to the bosh agent.
This does not work in a multi-SCSI controller environment such as Kubernetes, where disk devices may
be arbitrarily changed at reboot time (e.g. /dev/sda can't be assumed to be the root disk).

The existing behavior can lead to VMs locked up and/or Kubernetes PV data loss fter a VMware HA event, power outage/reboot, etc.

This fix detects if the VM has `disk.enableUUID` enabled in its extraConfig or `vmx_options`, which ensures
stable volume UUIDs between vSphere and the guest.  It will then use that UUID in its disk
identification to the BOSH agent, which already supports UUID matching.

## Related PR and Issues
Fixes PKS-341 (private JIRA)

## Impacted Areas in Application
List general components of the application that this PR will affect:

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## How Has This Been Tested?


- [X] Unit tests
- [X] Manual integration tests 

**Test Configuration**:
* Environment Variables for Integration test: 
* Hardware Requirements in ESXi: 6.5

# Checklist:

- [x] My code follows the standard ruby style guide
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
