### PR TITLE
WIP: Remove only relevant VM from server pool

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -455,7 +455,6 @@ module VSphereCloud
         logger.info("Deleting vm: #{vm_cid}")
 
         vm = vm_provider.find(vm_cid)
-        vm_ip = vm.mob.guest&.ip_address
 
         # find vm_groups vm is part of before deleting it
         cluster = vm.mob.runtime.host&.parent #host can be nil if vm is not running
@@ -483,7 +482,7 @@ module VSphereCloud
             logger.info("Failed to remove VM from NSGroups: #{e.message}")
           end
           begin
-            @nsxt_provider.remove_vm_from_server_pools(vm_ip)
+            @nsxt_provider.remove_vm_from_server_pools(vm)
           rescue => e
             logger.info("Failed to remove VM from ServerPool: #{e.message}")
           end

--- a/src/vsphere_cpi/lib/cloud/vsphere/nsxt_provider.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsxt_provider.rb
@@ -222,8 +222,8 @@ module VSphereCloud
         vm_ip = vm.mob.guest&.ip_address
         raise VirtualMachineIpNotFound.new(vm) unless vm_ip
         server_pools.each do |server_pool, port_no|
-          logger.info("Adding vm: '#{vm.cid}' with ip:#{vm_ip} to ServerPool: #{server_pool.id} on Port: #{port_no} ")
-          pool_member = NSXT::PoolMemberSetting.new(ip_address: vm_ip, port: port_no)
+          logger.info("Adding vm: '#{vm.cid}' with ip:#{vm_ip} on Port: #{port_no} to ServerPool: #{server_pool.id}")
+          pool_member = NSXT::PoolMemberSetting.new(ip_address: vm_ip, port: port_no, display_name: vm.cid)
           pool_member_setting_list = NSXT::PoolMemberSettingList.new(members: [pool_member])
           begin
             services_svc.perform_pool_member_action(server_pool.id, pool_member_setting_list, 'ADD_MEMBERS')
@@ -263,12 +263,13 @@ module VSphereCloud
       [static_server_pools, dynamic_server_pools]
     end
 
-    def remove_vm_from_server_pools(vm_ip)
-        services_svc.list_load_balancer_pools.results.each do |server_pool|
-        members_found = server_pool.members&.select {|member| member.ip_address == vm_ip}
+    def remove_vm_from_server_pools(vm)
+      vm_ip = vm.mob.guest&.ip_address
+      services_svc.list_load_balancer_pools.results.each do |server_pool|
+        members_found = server_pool.members&.select {|member| member.display_name == vm.cid && member.ip_address == vm_ip}
         next unless members_found&.any?
         members_found.each do |member_found|
-          logger.info("Removing vm with ip: '#{vm_ip}', port_no: #{member_found.port} from ServerPool: #{server_pool.id} ")
+          logger.info("Removing vm : '#{vm.cid}' and ip: '#{vm_ip}', port_no: #{member_found.port} from ServerPool: #{server_pool.id}")
           pool_member = NSXT::PoolMemberSetting.new(ip_address: vm_ip, port: member_found.port)
           pool_member_setting_list = NSXT::PoolMemberSettingList.new(members: [pool_member])
           services_svc.perform_pool_member_action(server_pool.id, pool_member_setting_list, 'REMOVE_MEMBERS')

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -1616,7 +1616,7 @@ module VSphereCloud
           expect(vm).to receive(:power_off)
           expect(vm).to receive(:delete)
           expect(nsxt_provider).to receive(:remove_vm_from_nsgroups).with(vm)
-          expect(nsxt_provider).to receive(:remove_vm_from_server_pools).with(ip_address)
+          expect(nsxt_provider).to receive(:remove_vm_from_server_pools).with(vm).once
           vsphere_cloud.delete_vm('vm-id')
         end
 
@@ -1627,7 +1627,7 @@ module VSphereCloud
             expect(nsxt_provider).to receive(:remove_vm_from_nsgroups).with(vm).and_raise(
               VIFNotFound.new('vm-id', 'fake-external-id')
             )
-            expect(nsxt_provider).to receive(:remove_vm_from_server_pools).with(ip_address)
+            expect(nsxt_provider).to receive(:remove_vm_from_server_pools).with(vm)
 
             vsphere_cloud.delete_vm('vm-id')
           end
@@ -1637,7 +1637,7 @@ module VSphereCloud
             expect(vm).to receive(:power_off)
             expect(vm).to receive(:delete)
             expect(nsxt_provider).to receive(:remove_vm_from_nsgroups).with(vm)
-            expect(nsxt_provider).to receive(:remove_vm_from_server_pools).with(ip_address).and_raise(
+            expect(nsxt_provider).to receive(:remove_vm_from_server_pools).with(vm).and_raise(
               NSXT::ApiCallError.new('NSX=T API error')
             )
             vsphere_cloud.delete_vm('vm-id')


### PR DESCRIPTION
# Description

- The delete_vm call only gets vm_cid from BOSH and not the cloud properties
        which contains details of all server pools to which the VM should be added too.
        DELETE_VM call in the absence of any cloud properties,
        does not know anything about pool members other than their IP.
        This IP is got from VC by searching the name of vm.
        So it goes on to remove that IP from all server pools which is
      - Only adding IP might result in deleting a wrong VM with same IP
        from the server pool. Adding a display_name == vm.cid provides for
        more context when deleting.
        wrong.


## Impacted Areas in Application
List general components of the application that this PR will affect:
NSXT Provider 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [ ] New Unit Test in nsxt_provider_spec.rb
- [ ] New Integration Test nsxt_provider_spec.rb

# Checklist:

- [x] My code follows the standard ruby style guide
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
