### PR TITLE
Fix for using NSX 6.4.5+. See issues/224

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/nsx.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsx.rb
@@ -98,7 +98,7 @@ module VSphereCloud
       pool_id = document.xpath('poolId').text
       document.xpath('member').remove
 
-      response = @http_client.put("https://#{@nsx_url}/api/4.0/edges/#{edge_id}/loadbalancer/config/pools/#{pool_id}", document.to_xml, { 'Content-Type' => 'text/xml' })
+      response = @http_client.put("https://#{@nsx_url}/api/4.0/edges/#{edge_id}/loadbalancer/config/pools/#{pool_id}", document.to_xml, { 'Content-Type' => 'text/xml', 'Accept' => 'text/xml' })
       unless response.status.between?(200, 299)
         raise "Failed to update Pool '#{pool_name}' under Edge '#{edge_name}' with unknown NSX error: '#{response.body}'"
       end
@@ -157,7 +157,7 @@ module VSphereCloud
         end
 
         pool_xml = create_pool_xml(pool_details, members_to_add)
-        response = @http_client.put("https://#{@nsx_url}/api/4.0/edges/#{edge_id}/loadbalancer/config/pools/#{pool_id}", pool_xml, { 'Content-Type' => 'text/xml' })
+        response = @http_client.put("https://#{@nsx_url}/api/4.0/edges/#{edge_id}/loadbalancer/config/pools/#{pool_id}", pool_xml, { 'Content-Type' => 'text/xml', 'Accept' => 'text/xml' })
         unless response.status.between?(200, 299)
           raise "Failed to update LB Pool ID '#{pool_id}' under Edge ID '#{edge_id}' with unknown NSX error: '#{response.body}'"
         end
@@ -294,7 +294,7 @@ module VSphereCloud
       response = @http_client.post(
         "https://#{@nsx_url}/api/2.0/services/securitygroup/bulk/globalroot-0",
         create_security_group_content(security_group_name),
-        {'Content-Type' => 'text/xml'}
+        { 'Content-Type' => 'text/xml', 'Accept' => 'text/xml' }
       )
       if response.status.between?(200, 299)
         return response.body


### PR DESCRIPTION
# Description

We found that a specific API endpoint was not responding in a way that we had come to expect.

This resulted in the issue 224 which was reported a while back.

Upon further investigation VMware release best practice on how to communicate with the API which basically involves specifying the Content-Type and Accept whenever you interact. This ensures that you either get xml or json responses as required.

## Related PR and Issues
Fixes https://github.com/cloudfoundry/bosh-vsphere-cpi-release/issues/224

## Impacted Areas in Application
List general components of the application that this PR will affect:

None

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

We have used these tweaks to generate a bosh deployment which we can manage when using NSX 6.4.6.