### PR TITLE
WIP:Support better human readable name with Tags

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -948,10 +948,19 @@ module VSphereCloud
     #   or a nil otherwise
     def update_name_info_from_bosh_env(environment)
       return nil if environment.nil?
+
       instance_group_name = environment.dig('bosh', 'groups', 2)
-      deployment_name = environment.dig('bosh', 'groups', 1)
+      # Try to extract deployment name from BOSH manifest tags first
+      # and then default deployment name passed by BOSH.
+      # This is done to avoid service_instanceXXXX style deployment names ODB generates.
+      deployment_name = environment.dig('bosh', 'tags', 'deployment')
+      if deployment_name.nil? || deployment_name == ''
+        deployment_name = environment.dig('bosh', 'groups', 1)
+      end
+
       return nil if instance_group_name.nil? || deployment_name.nil?
-      OpenStruct.new(inst_grp: instance_group_name, deployment: deployment_name)
+      # strip whitespaces
+      OpenStruct.new(inst_grp: instance_group_name.strip, deployment: deployment_name.strip)
     end
   end
 end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -2337,8 +2337,6 @@ module VSphereCloud
       end
 
       context "When environment has deployment and instance group name" do
-        let(:key1) {"instance_group_name"}
-        let(:key2) {"deployment_name"}
         let(:environment) do
           {
             'bosh' => {
@@ -2347,7 +2345,41 @@ module VSphereCloud
             }
           }
         end
-        it "returns an struct " do
+        it "returns a struct " do
+          result = vsphere_cloud.send(:update_name_info_from_bosh_env, environment)
+          expect(result).to_not be_nil
+          expect(result.inst_grp).to eq('fake-instance-group-name')
+          expect(result.deployment).to eq('fake-deployment-name')
+        end
+      end
+      context "When environment has a deployment tag, deployment name and instance group name" do
+        let(:environment) do
+          {
+              'bosh' => {
+                  'group' => 'fake-group',
+                  'groups' => ['fake-director-name', 'fake-deployment-name', 'fake-instance-group-name'],
+                  'tags' => {'deployment' => 'deployment_tag'}
+              }
+          }
+        end
+        it "returns a struct with deployment tag overriding default bosh deployment name " do
+          result = vsphere_cloud.send(:update_name_info_from_bosh_env, environment)
+          expect(result).to_not be_nil
+          expect(result.inst_grp).to eq('fake-instance-group-name')
+          expect(result.deployment).to eq('deployment_tag')
+        end
+      end
+      context "When environment has an empty deployment tag and deployment name and instance group name" do
+        let(:environment) do
+          {
+              'bosh' => {
+                  'group' => 'fake-group',
+                  'groups' => ['fake-director-name', 'fake-deployment-name', 'fake-instance-group-name'],
+                  'tags' => {'deployment' => ''}
+              }
+          }
+        end
+        it "returns a struct with default bosh deployment name " do
           result = vsphere_cloud.send(:update_name_info_from_bosh_env, environment)
           expect(result).to_not be_nil
           expect(result.inst_grp).to eq('fake-instance-group-name')


### PR DESCRIPTION
  - In cases of deployments which uses ODB in conjunction with BOSH,
  deployment names are generated in the form service-instance-xxxxx.
  This generates a complex name not relatable to actual deployment.

 - Starting BOSH release 270.10+ tags block in the manifest is passed to
  create_vm call's environment param. This can be used to generate a much
  better name.

  [#170987465](https://www.pivotaltracker.com/story/show/170987465)