### PR TITLE
Re write device keys for device change when cloning or reconfiguring VM

### DIFF
--- a/ci/config.rb
+++ b/ci/config.rb
@@ -49,3 +49,12 @@ $pipeline.pool('6.7-NSXT24') do |pool|
     NSXT_SKIP_SSL_VERIFY: "true"
   }
 end
+
+$pipeline.pool('7.0-NSXT30') do |pool|
+  pool.params = {
+      RSPEC_FLAGS: [
+          '--tag nsx_transformers'
+      ].join(' '),
+      NSXT_SKIP_SSL_VERIFY: "true"
+  }
+end

--- a/ci/pipeline/main.yml.erb
+++ b/ci/pipeline/main.yml.erb
@@ -27,6 +27,7 @@ jobs:
         - lifecycle-6.5-NSXT25
         - lifecycle-6.7-NSXT24
         - lifecycle-6.7-NSXT25
+        - lifecycle-7.0-NSXT30
       - get: version-semver
         trigger: false
         params: { bump: patch }
@@ -127,6 +128,7 @@ jobs:
         - lifecycle-6.5-NSXT25
         - lifecycle-6.7-NSXT24
         - lifecycle-6.7-NSXT25
+        - lifecycle-7.0-NSXT30
         - bats
     - put: tracker-output
       params: { repos: [bosh-cpi-src] }
@@ -216,6 +218,13 @@ resources:
       branch:       master
       pool:         v6.7-nsxt25
       private_key:  {{vcpi-pool_deployment_key}}
+  - name: pool-7.0-NSXT30
+    type: pool
+    source:
+      uri:          git@gitlab.eng.vmware.com:PKS/vcpi-pool.git
+      branch:       master
+      pool:         v7.0-nsxt30
+      private_key:  {{vcpi-pool_deployment_key}}
   - name: bosh-cpi-artifacts
     type: s3
     source:
@@ -300,6 +309,9 @@ groups:
   - lock-6.7-NSXT25
   - lifecycle-6.7-NSXT25
   - unlock-6.7-NSXT25
+  - lock-7.0-NSXT30
+  - lifecycle-7.0-NSXT30
+  - unlock-7.0-NSXT30
   - lock-6.7-NSXT24
   - lifecycle-6.7-NSXT24
   - unlock-6.7-NSXT24
@@ -322,6 +334,7 @@ groups:
   - lifecycle-6.5-NSXT25
   - lifecycle-6.5-NSXT24
   - lifecycle-6.0-NSXV
+  - lifecycle-7.0-NSXT30
   - bats
   - delivery
 
@@ -358,3 +371,11 @@ groups:
   - lifecycle-6.7-NSXT25
   - lock-6.7-NSXT25
   - unlock-6.7-NSXT25
+
+- name: v7.0
+  jobs:
+    - unit-test
+    - lifecycle-7.0-NSXT30
+    - lock-7.0-NSXT30
+    - unlock-7.0-NSXT30
+

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
@@ -117,6 +117,16 @@ module VSphereCloud
 
         replicated_stemcell_vm.fix_device_unit_numbers(config_spec.device_change)
 
+        # Re-assign new keys to devices being added.
+        # from vc api docs:
+        #   When adding new devices, it may be necessary for a client to assign keys temporarily
+        #   in order to associate controllers with devices in configuring a virtual machine.
+        #   However, the server does not allow a client to reassign a device key,
+        #   and the server may assign a different value from the one passed during configuration.
+        #   Clients should ensure that existing device keys are not reused as temporary key values
+        #   for the new device to be added (for example, by using unique negative integers as temporary keys).
+        replicated_stemcell_vm.fix_device_key(config_spec.device_change)
+
         if vm_config.vmx_options.is_a?(Hash)
           config_spec.extra_config = vm_config.vmx_options.keys.map { |key|
             VimSdk::Vim::Option::OptionValue.new(key: key, value: vm_config.vmx_options[key])


### PR DESCRIPTION
  - To support VC 7.0
     - VC 7.0 requires a unique temp key for each device we add to a VM.
     - Older CPI release used to add all devices with key as -1
     - Change to generate new temp key(negative integer) for each new
       device. Will account for already added device & their keys to a stemcell/VM.
     - Change accounts for create_vm (New NIC & Ephemeral Disk)
     - Change accounts for attach_disk (New Persistent Disk)

[#171032557](https://www.pivotaltracker.com/story/show/171032557)