### PR TITLE
Workaround HA alarms deleting VMs

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -482,6 +482,16 @@ module VSphereCloud
         end
         vm.power_off
 
+        begin
+          if vm.mob.resource_pool.owner.configuration.das_config.enabled && vm.mob.datastore.map { |x| x.summary.type}.include?("vsan")
+            # in HA configurations using vSan, vSphere may issue alarms if we delete VMs too quickly.
+            # The following sleep is a hacky workaround
+            sleep 15
+          end
+        rescue => e
+          logger.warn("failed detecting vSan HA: #{e}")
+        end
+
         persistent_disks = vm.persistent_disks
         unless persistent_disks.empty?
           vm.detach_disks(persistent_disks)


### PR DESCRIPTION
- When HA is enabled on a cluster and vSan datastores are in use, ESX
FDM can issue false alarms.
- FDM engineering suggests pausing after power down to give FDM
inventory time to catch up before we delete the VM.
- This change adds a delay for VMs that use vsan datastores deployed to
clusters with HA enabled.
- We think this should fix #284

Authored-by: Julian Hjortshoj <hjortshojj@vmware.com>

[#178490851](https://www.pivotaltracker.com/story/show/178490851)

