### PR TITLE
Add principal identity auth for the policy API

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_policy_api_client_builder.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_policy_api_client_builder.rb
@@ -10,14 +10,25 @@ module VSphereCloud
 
       configuration = NSXTPolicy::Configuration.new
       configuration.host = @config.host
-      configuration.username = @config.username
-      configuration.password = @config.password
       configuration.logger = @logger
       configuration.client_side_validation = false
       configuration.debugging = false
+
+      # Configure auth key/cert or user/paswords
+      if @config.auth_private_key
+        configuration.key_file = @config.auth_private_key
+        configuration.cert_file = @config.auth_certificate
+      else
+        configuration.username = @config.username
+        configuration.password = @config.password
+      end
+
+      # Root CA Cert
       if ENV['BOSH_NSXT_CA_CERT_FILE']
         configuration.ssl_ca_cert = ENV['BOSH_NSXT_CA_CERT_FILE']
       end
+
+      # SKIP SSL VALIDATION?
       if ENV['NSXT_SKIP_SSL_VERIFY']
         configuration.verify_ssl = false
         configuration.verify_ssl_host = false


### PR DESCRIPTION
When support for the policy API was added to the vSphere CPI, only user
/ password authentication was implemented. The management API supports
both user / password, and principal identity (certificate-based)
authentication.

This commit updates the policy API client builder to mirror what is
being done for the management API client builder
(`src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_api_client_builder.rb`).

[#182184669] [BOSH-139] Add option to configure NSX-T Policy API with cert/key pair

Signed-off-by: Rajan Agaskar <ragaskar@vmware.com>