### PR TITLE
Place persistent disks properly with vertical storage #182264101

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ releases/**/*.tgz
 dev_releases
 .blobs
 blobs
+*.nix
+vendor
+.bundle
 .dev_builds
 .idea
 .DS_Store

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
@@ -30,6 +30,11 @@ module VSphereCloud
         cluster['name']
       end
 
+      def cluster_mob
+        cluster = cloud_searcher.get_properties(host_properties['parent'], Vim::ClusterComputeResource, 'name', ensure_all: true)
+        cluster[:obj]
+      end
+
       def resource_pool
         properties['resourcePool'].name
       end
@@ -41,7 +46,7 @@ module VSphereCloud
             ensure_all: true
         ).select(&:accessible)
             .inject({}) do |acc, datastore|
-          acc[datastore.name] = datastore
+          acc[datastore.name] = datastore if datastore.accessible_from?(cluster_mob)
           acc
         end
       end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/vm_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/vm_spec.rb
@@ -34,20 +34,50 @@ describe VSphereCloud::Resources::VM, fake_logger: true do
 
   context 'accessible datastores' do
     let(:bytes_in_mb) {1024 * 1024}
+    let(:cluster_mob) { instance_double('VimSdk::Vim::ClusterComputeResource') }
     let(:accessible_datastore_properties) { {'name' => 'datastore-name',  'summary.accessible' => true, 'summary.freeSpace' => 20000 * bytes_in_mb, 'summary.capacity' => 40000 * bytes_in_mb} }
     let(:inaccessible_datastore_properties) { {'name' => 'inaccessible-datastore-name', 'summary.accessible' => false} }
+    let(:vertically_inaccessible_datastore_properties) { {'name' => 'vertically-inaccessible-datastore-name', 'summary.accessible' => true} }
     let(:datastore_mob) { instance_double('VimSdk::Vim::Datastore') }
     let(:inaccessible_datastore_mob) { instance_double('VimSdk::Vim::Datastore') }
+    let(:vertically_inaccessible_datastore_mob) { instance_double('VimSdk::Vim::Datastore') }
     let(:datastore_properties) do
       {
           instance_double('VimSdk::Vim::Datastore') => accessible_datastore_properties,
-          instance_double('VimSdk::Vim::Datastore') => inaccessible_datastore_properties
+          instance_double('VimSdk::Vim::Datastore') => inaccessible_datastore_properties,
+          instance_double('VimSdk::Vim::Datastore') => vertically_inaccessible_datastore_properties
       }
     end
+
     before do
+      accessible_ds = instance_double(VSphereCloud::Resources::Datastore,
+        name: "datastore-name",
+        maintenance_mode?: false,
+        accessible_from?: true,
+        accessible: true
+      )
+      inaccessible_ds = instance_double(VSphereCloud::Resources::Datastore,
+        name: "inaccessible-datastore-name",
+        maintenance_mode?: false,
+        accessible_from?: true,
+        accessible: false
+      )
+      vert_inaccessible_ds = instance_double(VSphereCloud::Resources::Datastore,
+        name: "inaccessible-datastore-name",
+        maintenance_mode?: false,
+        accessible_from?: false,
+        accessible: true
+      )
+
       host_properties = {
-          'datastore' => [datastore_mob, inaccessible_datastore_mob]
+        'datastore' => [datastore_mob, inaccessible_datastore_mob, vertically_inaccessible_datastore_mob]
       }
+      allow(cloud_searcher).to receive(:get_properties).with(
+        host_properties['parent'],
+        VimSdk::Vim::ClusterComputeResource,
+        "name",
+        ensure_all: true,
+      ).and_return({obj: cluster_mob})
       allow(cloud_searcher).to receive(:get_properties).with(
           'vm-host',
           VimSdk::Vim::HostSystem,
@@ -60,11 +90,11 @@ describe VSphereCloud::Resources::VM, fake_logger: true do
           VSphereCloud::Resources::Datastore::PROPERTIES,
           ensure_all: true,
       ).and_return(datastore_properties)
+      expect(VSphereCloud::Resources::Datastore).to receive(:build_from_client).and_return([accessible_ds,inaccessible_ds,vert_inaccessible_ds])
     end
     describe '#accessible_datastores' do
       it 'returns list of accessible datastores' do
         expect(vm.accessible_datastores.keys).to match_array(['datastore-name'])
-        expect(vm.accessible_datastores['datastore-name']).to be_a(VSphereCloud::Resources::Datastore)
       end
     end
     describe '#accessible_datastore_names' do


### PR DESCRIPTION
currently accessible datastores can return DS that is not
accessible to the compute cluster if vertical storage is
configured in a way where a DS is mapped to a Compute Cluster.

this is the persistent disk follow up to:  3ff70d187ce2aab8632f6b2aa1f35f5442d6564d

update tests for accessible_from? scenario

test expeactations needed to consider additional calls to cloud
searcher as well as the datastore.accessible_from?

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Related PR and Issues
https://github.com/cloudfoundry/bosh-vsphere-cpi-release/commit/3ff70d187ce2aab8632f6b2aa1f35f5442d6564d