### PR TITLE
Refresh group before each call to add_vm_to_group() when using nsxt policy provider

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/nsxt_policy_provider.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsxt_policy_provider.rb
@@ -60,6 +60,7 @@ module VSphereCloud
 
       groups.each do |group|
         retry_on_conflict("while adding vm: #{vm.cid} to group #{group.display_name}") do
+          group = retrieve_group(group_id: group.id)
           add_vm_to_group(group, vm.cid)
         end
       end


### PR DESCRIPTION
# Description

A quick fix adding a refresh of the group object each time before caling add_vm_to_group().

## Related PR and Issues
Fixes #328 

## Impacted Areas in Application
List general components of the application that this PR will affect:

- nsxt policy provider

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

We've deployed and tested the change using the process to reproduce from the issue - i.e. ran `bosh recreate` on multiple deployments which attempt to add vms to the same security group. 

**Test Configuration**:
vCenter Version 7.x
NSXT Version 3.x

# Checklist:

- [x] My code follows the standard ruby style guide
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] ~I have added tests that prove my fix is effective or that my feature works~
- [x] ~New and existing unit tests pass locally with my changes~
