### PR TITLE
fetch only required networks

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/vcenter_client.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vcenter_client.rb
@@ -251,7 +251,10 @@ module VSphereCloud
         when VimSdk::Vim::Folder
           container.child_entity
         when nil
-          datacenter.mob.network
+          network = @cloud_searcher.find_resources_by_property_path(datacenter.mob, 'Network', 'name') do |network_name|
+            network_name == name
+          end
+          [network].flatten
       end
 
       # Find networks that match the network name

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/vcenter_client_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/vcenter_client_spec.rb
@@ -549,6 +549,7 @@ module VSphereCloud
 
     describe '#find_network' do
       let(:datacenter) { instance_double(VSphereCloud::Resources::Datacenter) }
+      let(:datacenter_mob) { instance_double(Resources::Datacenter, mob: 'fake-mob') }
       let(:network_name) { 'network_1' }
 
       context 'when an opaque network and a DVS share the same name' do
@@ -557,7 +558,8 @@ module VSphereCloud
         let(:opaque_guid) { 'some_guid'}
         let(:dvs_guid) { 'some_guid'}
         before do
-          expect(datacenter).to receive_message_chain(:mob, :network).and_return([opaque_network, dvs_network])
+          expect(cloud_searcher).to receive(:find_resources_by_property_path).and_return([opaque_network, dvs_network])
+          expect(datacenter).to receive(:mob).and_return(datacenter_mob)
           allow(opaque_network).to receive_message_chain(:summary, :opaque_network_id).and_return(opaque_guid)
           allow(dvs_network).to receive_message_chain(:config, :respond_to?).and_return(true)
           allow(dvs_network).to receive_message_chain(:config, :backing_type).and_return('nsx')


### PR DESCRIPTION
follow up to:

12b6428383b1d45d9d8232bca4f4b2b950f9582a
7f3dfe9b37bc1e9e94ac111a2a736ac8ae1a0562
bfbace570bab8516ab74ca74e6b60efc7f572540

The revert in 7f3dfe9b37bc1e9e94ac111a2a736ac8ae1a0562 was right.
Using find_by_inventory_path in that context would've lead to issues
for nested networks (meaning networks contained in folder that are not
direct child entities of the datacenter). Unfortunately the follow up
fix in bfbace570bab8516ab74ca74e6b60efc7f572540 didn't solve the
underlying problems.

the problem is iterating through all the networks client side takes time.
In fact a lot of time and thus creates time of use vs time of check issues
as pointed out in the initial fix in 12b6428383b1d45d9d8232bca4f4b2b950f9582a

The underlying list of available networks in our scenario is HIGHLY
dynamic because the Kubernetes CloudProvider is creating/deleting them
automatically for Kubernetes Namespaces. These can range in the hundreds
for a single Kubernetes Cluster. In case of deleted networks this creates
an issue for us since we already cached the network (via `datacenter.networks`)
and when we subsequently try to access it's name it is already deleted
on vsphere because the underlying namespace got deleted on Kubernetes.

The fix in 12b6428383b1d45d9d8232bca4f4b2b950f9582a solved that
problem but unfortunately wouldn't have discovered nested networks as
pointed out by the revert. This is due to the usage of find_by_inventory_path
as opposed to `find_resources_by_property_path` in this commit. The latter
will use `get_recursive_search_filter_spec` which will in fact discover
networks contained in folders.

fixes:

```
'vim.OpaqueNetwork:network-o66920' has already been deleted or has not been completely created'.
W, [2022-06-17T11:19:25.399024 #32493]  WARN -- [req_id cpi-738243]: Error running method 'RetrieveProperties'. Failed with message 'The object 'vim.OpaqueNetwork:network-o66920' has already been deleted or has not been completely created'.
W, [2022-06-17T11:19:25.414357 #32503]  WARN -- [req_id cpi-225911]: Error running method 'RetrieveProperties'. Failed with message 'The object 'vim.OpaqueNetwork:network-o66920' has already been deleted or has not been completely created'.
W, [2022-06-17T11:19:25.551653 #32502]  WARN -- [req_id cpi-848439]: Error running method 'RetrieveProperties'. Failed with message 'The object 'vim.OpaqueNetwork:network-o66920' has already been deleted or has not been completely created'.
```

and similar Issues for CVDS objects.
