### PR TITLE
Replace deprecated `overallUsage` with `hostMemoryUsage`

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/cluster.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/cluster.rb
@@ -230,8 +230,9 @@ module VSphereCloud
         raise "Failed to get utilization for resource pool '#{resource_pool}'" if properties.nil?
 
         runtime_info = properties["summary"].runtime
+        quick_stats = properties["summary"].quick_stats
         memory = runtime_info.memory
-        return (memory.max_usage - memory.overall_usage) / BYTES_IN_MB
+        return (memory.max_usage - (quick_stats.host_memory_usage) * 1024) / BYTES_IN_MB
       end
     end
   end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/cluster_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/cluster_spec.rb
@@ -80,6 +80,12 @@ module VSphereCloud::Resources
       )
     end
 
+    let(:fake_quick_stats) do
+      instance_double(
+        'VimSdk::Vim::ResourcePool::Summary::QuickStats',
+      )
+    end
+
     before do
       allow(ResourcePool).to receive(:new).with(
         client, cluster_config, fake_resource_pool_mob, datacenter_name
@@ -92,7 +98,7 @@ module VSphereCloud::Resources
       allow(cloud_searcher).to receive(:get_properties).with(
         fake_resource_pool_mob, VimSdk::Vim::ResourcePool, "summary"
       ).and_return({
-        'summary' => instance_double('VimSdk::Vim::ResourcePool::Summary', runtime: fake_runtime_info)
+        'summary' => instance_double('VimSdk::Vim::ResourcePool::Summary', runtime: fake_runtime_info, quick_stats: fake_quick_stats)
       })
     end
 
@@ -144,8 +150,14 @@ module VSphereCloud::Resources
                 memory: instance_double(
                   'VimSdk::Vim::ResourcePool::ResourceUsage',
                   max_usage: 1024 * 1024 * 100,
-                  overall_usage: 1024 * 1024 * 75,
                 )
+              )
+            end
+
+            let(:fake_quick_stats) do
+              instance_double(
+                'VimSdk::Vim::ResourcePool::Summary::QuickStats',
+                host_memory_usage: 1024 * 75
               )
             end
 
@@ -351,8 +363,14 @@ module VSphereCloud::Resources
           memory: instance_double(
             'VimSdk::Vim::ResourcePool::ResourceUsage',
             max_usage: 1024 * 1024 * 100,
-            overall_usage: 1024 * 1024 * 75,
           )
+        )
+      end
+
+      let(:fake_quick_stats) do
+        instance_double(
+          'VimSdk::Vim::ResourcePool::Summary::QuickStats',
+          host_memory_usage: 1024 * 75
         )
       end
 


### PR DESCRIPTION
As noted here: https://vdc-repo.vmware.com/vmwb-repository/dcr-public/1ef6c336-7bef-477d-b9bb-caa1767d7e30/82521f49-9d9a-42b7-b19b-9e6cd9b30db1/vim.ResourcePool.ResourceUsage.html `overallUsage` has been deprecated. `hostMemoryUsage` is the prefered replacement.

The values returned from `hostMemoryUsage` are in MB rather than Bytes but otherwise seem similar on the resource pool object I tested it on.