### PR TITLE
Fix broken offline environment create-env

### DIFF
--- a/packages/vsphere_cpi/packaging
+++ b/packages/vsphere_cpi/packaging
@@ -10,7 +10,8 @@ cp -a vsphere_cpi/* ${BOSH_INSTALL_TARGET}
 
 cd ${BOSH_INSTALL_TARGET}
 
-BUNDLE_DEPLOYMENT="true" \
-BUNDLE_CACHE_PATH="vendor/package" \
-BUNDLE_WITHOUT="development:test" \
-bundle install --local
+bundle config set --local deployment 'true'
+bundle config set --local no_prune 'true'
+bundle config set --local without 'development test'
+
+bundle install


### PR DESCRIPTION
bundler stopped picking up some cli flags and some env vars. there have
been warnings around this but we do not see them when the create-env
succeeds. It wasn't caught in CI since the CI environment is not
internetless. So bundler was still able to reach out to get the
gems that were already present locally (which it ignored because it
ignored the cli flags)

Signed-off-by: jpalermo <jpalermo@vmware.com>

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Related PR and Issues
Fixes # (issue)

## Impacted Areas in Application
List general components of the application that this PR will affect:

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Environment Variables for Integration test:
* Hardware Requirements in ESXi:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the standard ruby style guide
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
