### PR TITLE
Expose memory_reservation_locked_to_max via cloud_properties

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
@@ -122,6 +122,7 @@ module VSphereCloud
       params = {}
       params[:num_cpus] = vm_type.cpu
       params[:memory_mb] = vm_type.ram
+      params[:memory_reservation_locked_to_max] = true if vm_type.memory_reservation_locked_to_max
       params[:nested_hv_enabled] = true if vm_type.nested_hardware_virtualization
       params[:cpu_hot_add_enabled] = true if vm_type.cpu_hot_add_enabled
       params[:memory_hot_add_enabled] = true if vm_type.memory_hot_add_enabled

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_type.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_type.rb
@@ -15,7 +15,7 @@ module VSphereCloud
     end
 
     %w[cpu ram disk cpu_hot_add_enabled memory_hot_add_enabled nsx vmx_options
-       nsxt nested_hardware_virtualization upgrade_hw_version datacenters vm_group disable_drs storage_policy tags].each do |name|
+       nsxt memory_reservation_locked_to_max nested_hardware_virtualization upgrade_hw_version datacenters vm_group disable_drs storage_policy tags].each do |name|
       define_method(name) { @cloud_properties[name] }
     end
 

--- a/src/vsphere_cpi/spec/integration/multi_cluster_overflow_spec.rb
+++ b/src/vsphere_cpi/spec/integration/multi_cluster_overflow_spec.rb
@@ -99,7 +99,7 @@ context 'given 2 clusters with a datastore and a resource pool' do
       update_resource_pool_memory_reservation(cpi, @first_cluster_name, @first_rp, 1, true)
       update_resource_pool_memory_reservation(cpi, @second_cluster_name, @second_rp, 1, true)
     end
-    it 'should create a VM on the first cluster' do
+    it 'should create a VM on the second cluster' do
       begin
         @vm_id, _ = cpi.create_vm(
           'agent-007',

--- a/src/vsphere_cpi/spec/integration/multi_cluster_overflow_spec.rb
+++ b/src/vsphere_cpi/spec/integration/multi_cluster_overflow_spec.rb
@@ -1,0 +1,123 @@
+require 'integration/spec_helper'
+
+context 'given 2 clusters with a datastore and a resource pool' do
+  before (:all) do
+    @first_cluster_name = fetch_and_verify_cluster('BOSH_VSPHERE_CPI_CLUSTER')
+    @second_cluster_name = fetch_and_verify_cluster('BOSH_VSPHERE_CPI_SECOND_CLUSTER')
+    @datastore_pattern = fetch_property('BOSH_VSPHERE_CPI_MULTI_LOCAL_DATASTORE_PATTERN')
+    @first_rp = fetch_and_verify_resource_pool('BOSH_VSPHERE_CPI_RESOURCE_POOL', @first_cluster_name)
+    @second_rp = fetch_and_verify_resource_pool('BOSH_VSPHERE_CPI_SECOND_CLUSTER_RESOURCE_POOL', @second_cluster_name)
+  end
+
+  let(:vm_type) do
+    {
+      'ram' => 512,
+      'disk' => 2048,
+      'cpu' => 1,
+      'memory_reservation_locked_to_max' => true,
+    }
+  end
+  let(:cpi) do
+    options = cpi_options(
+      datacenters: [{
+        datastore_pattern: @datastore_pattern,
+        clusters: [
+          { @first_cluster_name => { resource_pool: @first_rp }},
+          { @second_cluster_name => { resource_pool: @second_rp }},
+        ]
+      }]
+    )
+    VSphereCloud::Cloud.new(options)
+  end
+
+  after do
+    cpi.cleanup
+  end
+
+  context 'when no cluster has enough reservable memory' do
+    before do
+      update_resource_pool_memory_reservation(cpi, @first_cluster_name, @first_rp, 100, false)
+      update_resource_pool_memory_reservation(cpi, @second_cluster_name, @second_rp, 100, false)
+    end
+    after do
+      update_resource_pool_memory_reservation(cpi, @first_cluster_name, @first_rp, 1, true)
+      update_resource_pool_memory_reservation(cpi, @second_cluster_name, @second_rp, 1, true)
+    end
+    it 'should raise error for insufficient available Memory' do
+      begin
+        expect {
+          cpi.create_vm(
+            'agent-007',
+            @stemcell_id,
+            vm_type,
+            get_network_spec,
+            [],
+            {}
+          )
+        }.to raise_error(/The available Memory resources in the parent resource pool are insufficient for the operation./)
+      end
+    end
+  end
+
+  context 'when the first cluster has enough reservable memory' do
+    before do
+      update_resource_pool_memory_reservation(cpi, @first_cluster_name, @first_rp, 1024, false)
+      update_resource_pool_memory_reservation(cpi, @second_cluster_name, @second_rp, 100, false)
+    end
+    after do
+      update_resource_pool_memory_reservation(cpi, @first_cluster_name, @first_rp, 1, true)
+      update_resource_pool_memory_reservation(cpi, @second_cluster_name, @second_rp, 1, true)
+    end
+    it 'should create a VM on the first cluster' do
+      begin
+        @vm_id, _ = cpi.create_vm(
+          'agent-007',
+          @stemcell_id,
+          vm_type,
+          get_network_spec,
+          [],
+          {}
+        )
+
+        expect(@vm_id).to_not be_nil
+        expect(cpi.has_vm?(@vm_id)).to be(true)
+
+        vm = @cpi.vm_provider.find(@vm_id)
+        expect(vm.mob.runtime.host.parent.name).to eq(@first_cluster_name)
+      ensure
+        delete_vm(cpi, @vm_id)
+      end
+    end
+  end
+
+  context 'when the second cluster has enough reservable memory' do
+    before do
+      update_resource_pool_memory_reservation(cpi, @first_cluster_name, @first_rp, 100, false)
+      update_resource_pool_memory_reservation(cpi, @second_cluster_name, @second_rp, 1024, false)
+    end
+    after do
+      update_resource_pool_memory_reservation(cpi, @first_cluster_name, @first_rp, 1, true)
+      update_resource_pool_memory_reservation(cpi, @second_cluster_name, @second_rp, 1, true)
+    end
+    it 'should create a VM on the first cluster' do
+      begin
+        @vm_id, _ = cpi.create_vm(
+          'agent-007',
+          @stemcell_id,
+          vm_type,
+          get_network_spec,
+          [],
+          {}
+        )
+
+        expect(@vm_id).to_not be_nil
+        expect(cpi.has_vm?(@vm_id)).to be(true)
+
+        vm = @cpi.vm_provider.find(@vm_id)
+        expect(vm.mob.runtime.host.parent.name).to eq(@second_cluster_name)
+      ensure
+        delete_vm(cpi, @vm_id)
+      end
+    end
+  end
+end

--- a/src/vsphere_cpi/spec/support/lifecycle_helpers.rb
+++ b/src/vsphere_cpi/spec/support/lifecycle_helpers.rb
@@ -636,6 +636,21 @@ module LifecycleHelpers
     reconfigure_cluster(cpi, cluster, config_spec)
   end
 
+  def update_resource_pool_memory_reservation(cpi, cluster_name, resource_pool_name, memory_reservation, expandable_reservation)
+    cluster = cpi.client.cloud_searcher.get_managed_object(VimSdk::Vim::ClusterComputeResource, name: cluster_name)
+    datacenter_cluster_path_prefix = "#{cpi.datacenter.name}/host/#{cluster_name}/Resources/"
+    full_inventory_path = datacenter_cluster_path_prefix + resource_pool_name
+    resource_pool = cpi.client.service_content.search_index.find_by_inventory_path(full_inventory_path)
+
+    resource_spec = VimSdk::Vim::ResourceConfigSpec.new
+    resource_spec.cpu_allocation = resource_pool.config.cpu_allocation
+    resource_spec.memory_allocation = resource_pool.config.memory_allocation
+    resource_spec.memory_allocation.reservation = memory_reservation
+    resource_spec.memory_allocation.expandable_reservation = expandable_reservation
+
+    resource_pool.update_config(resource_pool_name, resource_spec)
+  end  
+
   private
 
   def is_disk_in_datastores(cpi, disk_id, accessible_datastores)

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_config_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_config_spec.rb
@@ -576,6 +576,26 @@ module VSphereCloud
         end
       end
 
+      context 'when memory_reservation_locked_to_max is false' do
+        let(:cloud_properties) { { 'memory_reservation_locked_to_max' => false } }
+        let(:input) { { vm_type: vm_type } }
+        let(:output) { {} }
+
+        it 'does not set any value in the config spec params' do
+          expect(vm_config.config_spec_params).to eq(output)
+        end
+      end
+
+      context 'when memory_reservation_locked_to_max is true' do
+        let(:cloud_properties) { { 'memory_reservation_locked_to_max' => true } }
+        let(:input) { { vm_type: vm_type } }
+        let(:output) { { memory_reservation_locked_to_max: true } }
+
+        it 'sets it to true' do
+          expect(vm_config.config_spec_params).to eq(output)
+        end
+      end            
+
       context 'when cpu_hot_add_enabled is true' do
         let(:cloud_properties) { { 'cpu_hot_add_enabled' => true } }
         let(:input) { { vm_type: vm_type } }


### PR DESCRIPTION
# Description
By setting this property all guest memory will be reserved. If a VM has more memory reserved than is available in a given resource pool it will fail to power on.

For multi-cluster configurations where resource pool memory reservations have been set some logic has been added which will try the next available cluster in case of a VM power-on failure.

## Impacted Areas in Application
List general components of the application that this PR will affect:

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?
Integration tests have been successfully run against one of the pooled ci environments. 