### PR TITLE
Make try next cluster on power on failure work with vSphere 6.5

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
@@ -235,7 +235,7 @@ module VSphereCloud
             # Power on VM
             logger.info("Powering on VM: #{created_vm}")
             created_vm.power_on
-          rescue VSphereCloud::VMPowerOnError => e
+          rescue VSphereCloud::VMPowerOnError, VSphereCloud::VCenterClient::TaskException => e
             logger.info("Failed to power on vm '#{vm_config.name}' with message:  #{e.inspect}")
             begin
               @cpi.delete_vm(created_vm.cid) if created_vm


### PR DESCRIPTION
The changes introduced in: baf997dd1b323015e93dc91b512e396249cf3708 did not work on vSphere 6.5 because the exception raised was of a different type.