### PR TITLE
In NSX-T Policy mode, expect `nsxt[ns_groups]` to specify Group ids.

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -939,10 +939,10 @@ module VSphereCloud
         @nsxt_policy_provider.add_vm_to_server_pools(created_vm, static_server_pools) if static_server_pools
       end
       groups = []
-      groups = @nsxt_policy_provider.retrieve_groups_by_name(ns_groups) unless ns_groups.empty?
+      groups = @nsxt_policy_provider.retrieve_groups_by_id(ns_groups) unless ns_groups.empty?
       if (ns_groups.count > groups.count)
         if allow_missing_resources
-          logger.info("Not all specified groups found, missing #{(ns_groups - groups.map(&:display_name)).join(",")}. VM will still be added to found groups (#{groups.map(&:display_name).join(",")})")
+          logger.info("Not all specified groups found, missing groups with ID(s) #{(ns_groups - groups.map(&:id)).join(",")}. VM will still be added to found groups (#{groups.map(&:id).join(",")})")
         else
           raise MissingNSXTGroups.new("Expected to find #{ns_groups.count} groups with names #{ns_groups}, only found #{groups.count}: #{groups.map(&:display_name)}")
         end

--- a/src/vsphere_cpi/lib/cloud/vsphere/nsxt_policy_provider.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsxt_policy_provider.rb
@@ -175,13 +175,6 @@ module VSphereCloud
     end
 
     #We don't page here but extremely unlikely to hit the pagination limit.
-    def retrieve_groups_by_name(group_display_names)
-      logger.info("Searching for Policy Groups with group display names: #{group_display_names}")
-      query = "resource_type:Group AND display_name:(#{group_display_names.join(" OR ")})"
-      search_api.query_search(query).results.map { |group_attrs| NSXTPolicy::Group.new(group_attrs) }
-    end
-
-    #We don't page here but extremely unlikely to hit the pagination limit.
     def retrieve_groups_by_id(group_ids)
       logger.info("Searching for Policy Groups with group ids: #{group_ids}")
       query = "resource_type:Group AND id:(#{group_ids.join(" OR ")})"

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -1221,16 +1221,16 @@ module VSphereCloud
             let(:group_1) { double(NSXTPolicy::Group, id: 'fake-nsgroup-1-id', display_name: "fake nsgroup 1") }
             let(:group_2) { double(NSXTPolicy::Group, id: 'fake-nsgroup-2-id', display_name: "fake nsgroup 2") }
             let(:vm_type_nsxt_config) do
-              { 'ns_groups' => [group_1.display_name, group_2.display_name] }
+              { 'ns_groups' => [group_1.id, group_2.id] }
             end
 
             before do
-              allow(nsxt_policy_provider).to receive(:retrieve_groups_by_name).with(["fake nsgroup 1", "fake nsgroup 2"]).and_return([group_1, group_2])
+              allow(nsxt_policy_provider).to receive(:retrieve_groups_by_id).with(["fake-nsgroup-1-id", "fake-nsgroup-2-id"]).and_return([group_1, group_2])
             end
 
             it "calls policy_provider#add_vm_to_groups AND provider#add_vm_to_nsgroups with the vm and ns_groups values" do
               expect(nsxt_policy_provider).to receive(:add_vm_to_groups).with(fake_vm, [group_1, group_2])
-              expect(nsxt_provider).to receive(:add_vm_to_nsgroups).with(fake_vm, [group_1.display_name, group_2.display_name])
+              expect(nsxt_provider).to receive(:add_vm_to_nsgroups).with(fake_vm, [group_1.id, group_2.id])
 
 
               vsphere_cloud.create_vm(
@@ -1244,10 +1244,10 @@ module VSphereCloud
             end
 
             it "adds _just_ to found groups if not all groups are found." do
-              allow(nsxt_policy_provider).to receive(:retrieve_groups_by_name).with(["fake nsgroup 1", "fake nsgroup 2"]).and_return([group_1])
-              expect(logger).to receive(:info).with("Not all specified groups found, missing fake nsgroup 2. VM will still be added to found groups (fake nsgroup 1)")
+              allow(nsxt_policy_provider).to receive(:retrieve_groups_by_id).with(["fake-nsgroup-1-id", "fake-nsgroup-2-id"]).and_return([group_1])
+              expect(logger).to receive(:info).with("Not all specified groups found, missing groups with ID(s) fake-nsgroup-2-id. VM will still be added to found groups (fake-nsgroup-1-id)")
               expect(nsxt_policy_provider).to receive(:add_vm_to_groups).with(fake_vm, [group_1])
-              expect(nsxt_provider).to receive(:add_vm_to_nsgroups).with(fake_vm, [group_1.display_name, group_2.display_name])
+              expect(nsxt_provider).to receive(:add_vm_to_nsgroups).with(fake_vm, [group_1.id, group_2.id])
 
               vsphere_cloud.create_vm(
                 'fake-agent-id',
@@ -1358,11 +1358,11 @@ module VSphereCloud
             let(:group_1) { double(NSXTPolicy::Group, id: 'fake-nsgroup-1-id', display_name: "fake nsgroup 1") }
             let(:group_2) { double(NSXTPolicy::Group, id: 'fake-nsgroup-2-id', display_name: "fake nsgroup 2") }
             let(:vm_type_nsxt_config) do
-              { 'ns_groups' => ['fake nsgroup 1', 'fake nsgroup 2'] }
+              { 'ns_groups' => [group_1.id, group_2.id] }
             end
 
             before do
-              allow(nsxt_policy_provider).to receive(:retrieve_groups_by_name).with(["fake nsgroup 1", "fake nsgroup 2"]).and_return([group_1, group_2])
+              allow(nsxt_policy_provider).to receive(:retrieve_groups_by_id).with(["fake-nsgroup-1-id", "fake-nsgroup-2-id"]).and_return([group_1, group_2])
             end
 
             it "calls policy_provider#add_vm_to_nsgroups with the vm and ns_groups values" do
@@ -1379,7 +1379,7 @@ module VSphereCloud
 
             context "when not all groups specified in ns_groups can be found" do
               it "rolls back vm creation" do
-                allow(nsxt_policy_provider).to receive(:retrieve_groups_by_name).with(["fake nsgroup 1", "fake nsgroup 2"]).and_return([group_1])
+                allow(nsxt_policy_provider).to receive(:retrieve_groups_by_id).with(["fake-nsgroup-1-id", "fake-nsgroup-2-id"]).and_return([group_1])
                 expect(nsxt_policy_provider).not_to receive(:add_vm_to_groups)
                 expect(vsphere_cloud).to receive(:delete_vm).with(fake_vm.cid)
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/nsxt_helpers/nsxt_policy_provider_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/nsxt_helpers/nsxt_policy_provider_spec.rb
@@ -845,37 +845,6 @@ describe VSphereCloud::NSXTPolicyProvider, fake_logger: true do
 
   end
 
-  describe "#retrieve_groups_by_name" do
-    let(:group_1_attributes) { { id: 'fake-nsgroup-1-id', display_name: "fake nsgroup 1", expression: [] } }
-    let(:group_2_attributes) { { id: 'fake-nsgroup-2-id', display_name: "fake nsgroup 2", expression: [] } }
-    let(:group_1) { NSXTPolicy::Group.new(group_1_attributes) }
-    let(:group_2) { NSXTPolicy::Group.new(group_2_attributes) }
-
-    before do
-        allow(search_api).to receive(:query_search).with("resource_type:Group AND display_name:(fake nsgroup 1 OR fake nsgroup 2)").
-          and_return(double(NSXTPolicy::SearchResponse, results: results) )
-    end
-
-    context "when all groups are found" do
-      let(:results) { [group_1_attributes, group_2_attributes] }
-      it "returns all groups" do
-        expect(nsxt_policy_provider.retrieve_groups_by_name([group_1.display_name, group_2.display_name])).to contain_exactly(group_1, group_2)
-      end
-    end
-    context "when some groups are found" do
-      let(:results) { [group_1_attributes] }
-      it "returns found groups" do
-        expect(nsxt_policy_provider.retrieve_groups_by_name([group_1.display_name, group_2.display_name])).to contain_exactly(group_1)
-      end
-    end
-    context "when no groups are found" do
-      let(:results) { [] }
-      it "returns found groups" do
-        expect(nsxt_policy_provider.retrieve_groups_by_name([group_1.display_name, group_2.display_name])).to eq([])
-      end
-    end
-
-  end
 
   describe "#retrieve_groups_by_id" do
     let(:group_1_attributes) { { id: 'fake-nsgroup-1-id', display_name: "fake nsgroup 1", expression: [] } }


### PR DESCRIPTION
# Description
- Groups and NS Groups can be retrieved from the NSX-T API by ID or display name. Policy API Groups are an equivalent to Management API NS Groups.
- Group IDs and display_names are not guaranteed to match.
  - On the Policy API side, we've found that for UI-created Groups, the ID _will_ match the display_name _if_ 1) the display name does not contain special characters (like spaces, slashes) AND 2) the display name is unique.
  - On the Management API side, a NSGroup created through the UI appears to have a GUID generated as the ID (it will _never_ match the display_name).
- When talking to the Management API the CPI uses a NS Group display_names to retrieve groups.
- After this commit, when talking to the Policy API, the CPI uses Group ids to retrieve groups.
- We've _deliberately_ chosen to retrieve Groups by ID from the Policy API, even though this does not match Management API behavior.
- This represents a return to the behavior used when the Policy API code was originally written. This effectively reverts 6113c106df6c7a9164b9b76f465143224b8dda0c.
- This resolves a problem for Policy API users who have Groups with non-unique or invalid-as-an-id display_names.
- However, it introduces a potential problem for users when in migration mode. Migration mode intends to update Groups in both Management and Policy APIs, and after this change, the NS Group display name in the Management API _must match_ the Group id in the Policy API for the migration mode to work as expected.
- The net effect of this change is that it is the users' responsibility in a migration scenario to ensure that the passed `ns_groups` values will work correctly for each API.
- `NsxtPolicyProvider#retrieve_groups_by_name` was removed because it is no longer used.


## Impacted Areas in Application
NSX-T behavior

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [-] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X]  Integration tests
- [X] Unit tests

# Checklist:

- [X ] My code follows the standard ruby style guide
- [X ] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] I have added tests that prove my fix is effective or that my feature works
- [X ] New and existing unit tests pass locally with my changes
