### PR TITLE
Ensure RP config has been updated in integration tests.

### DIFF
--- a/src/vsphere_cpi/spec/support/lifecycle_helpers.rb
+++ b/src/vsphere_cpi/spec/support/lifecycle_helpers.rb
@@ -649,7 +649,16 @@ module LifecycleHelpers
     resource_spec.memory_allocation.expandable_reservation = expandable_reservation
 
     resource_pool.update_config(resource_pool_name, resource_spec)
-  end  
+
+    #refetch resource_pool to ensure config has been updated -- may fix a race condition we see with vSphere 6.5
+    refresh_attempts = 0
+    while refresh_attempts < 5 do
+      resource_pool = cpi.client.service_content.search_index.find_by_inventory_path(full_inventory_path)
+      break if resource_pool.config.memory_allocation.reservation == memory_reservation && resource_pool.config.memory_allocation.expandable_reservation == expandable_reservation
+      refresh_attempts += 1
+      sleep 2
+    end
+  end
 
   private
 


### PR DESCRIPTION
- With the new multi_cluster_overflow_spec.rb we are seeing failures on vSphere 6.5. It looks like there _may_ be a race in between when the resource pool memory configuration is updated and the VM is placed such that the limits do not correctly apply to the VM. This bit of code attempts to ensure the settings have taken effect.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Related PR and Issues
Fixes # (issue)

## Impacted Areas in Application
List general components of the application that this PR will affect:

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Environment Variables for Integration test:
* Hardware Requirements in ESXi:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the standard ruby style guide
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
