### PR TITLE
Attempt to prefetch portgroup data

### DIFF
--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/vcenter_client_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/vcenter_client_spec.rb
@@ -795,18 +795,21 @@ module VSphereCloud
     describe '#dvpg_istype_nsxt' do
 
       let(:datacenter) { instance_double('VSphereCloud::Resources::Datacenter') }
+      let(:datacenter_mob) { instance_double(Resources::Datacenter, mob: 'fake-mob') }
       let(:portgroup) { 'dvpg1' }
       let(:key) { 'dvpg1' }
 
       context 'when network is not of type dvpg' do
         it 'should return false if portgroup is nil' do
-          expect(datacenter).to receive_message_chain(:mob, :network, :detect).and_return(nil)
+          expect(datacenter).to receive(:mob).and_return(datacenter_mob)
+          expect(cloud_searcher).to receive(:find_resources_by_property_path).and_return(nil)
 
           result = client.dvpg_istype_nsxt?(key: 'dvpg1', dc_mob: datacenter.mob)
           expect(result).to eq(false)
         end
         it 'should return false if portgroup does not have a backing type attribute' do
-          expect(datacenter).to receive_message_chain(:mob, :network, :detect).and_return(portgroup)
+          expect(datacenter).to receive(:mob).and_return(datacenter_mob)
+          expect(cloud_searcher).to receive(:find_resources_by_property_path).and_return(portgroup)
           expect(portgroup).to receive_message_chain(:config, :respond_to?).and_return(false)
 
           result = client.dvpg_istype_nsxt?(key: 'dvpg1', dc_mob: datacenter.mob)
@@ -814,7 +817,8 @@ module VSphereCloud
         end
         it 'should print an info log and return true if portgroup backing type is nsxt' do
           expect(logger).to receive(:info).with("Checking if #{key} is backed by NSXT")
-          expect(datacenter).to receive_message_chain(:mob, :network, :detect).and_return(portgroup)
+          expect(datacenter).to receive(:mob).and_return(datacenter_mob)
+          expect(cloud_searcher).to receive(:find_resources_by_property_path).and_return(portgroup)
           allow(portgroup).to receive_message_chain(:config, :respond_to?).with(:backing_type).and_return(true)
           allow(portgroup).to receive_message_chain(:config, :backing_type).and_return('nsx')
           allow(logger).to receive(:info).with("DVPG #{key} is backed by NSXT")


### PR DESCRIPTION
This commit largely follows the pattern established by the fix in
<https://github.com/cloudfoundry/bosh-vsphere-cpi-release/pull/332>.
Given that the complaint in
<https://github.com/cloudfoundry/bosh-vsphere-cpi-release/issues/336>
is similar to the one that caused the fix in #332, I believe that following the same pattern may be helpful.

The hope is that `find_resources_by_property_path` will both only select `DistributedVirtualPortgroup` objects, and also pre-fetch the `key` property of all of the objects returned. If it does this, then we should avoid attempting to fetch information about deleted vSphere networking objects, and only get the class of objects we're interested in.

Do note that I've only run the unit tests (which are pretty thoroughly mocked out), so the integration tests may fail.

[#183583921] BOSH-172 - TAS deployment failure during network churn

## Impacted Areas in Application
Port Group fetching

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests run locally

**Test Configuration**:
`be rspec spec` was run on a Bosh Ecosystem Team standard workstation.

# Checklist:

- [ ] My code follows the standard ruby style guide
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
