### PR TITLE
Fix 6.5-lifecycle tests.

### DIFF
--- a/src/vsphere_cpi/spec/support/lifecycle_helpers.rb
+++ b/src/vsphere_cpi/spec/support/lifecycle_helpers.rb
@@ -650,13 +650,9 @@ module LifecycleHelpers
 
     resource_pool.update_config(resource_pool_name, resource_spec)
 
-    #refetch resource_pool to ensure config has been updated -- may fix a race condition we see with vSphere 6.5
-    refresh_attempts = 0
-    while refresh_attempts < 5 do
-      resource_pool = cpi.client.service_content.search_index.find_by_inventory_path(full_inventory_path)
-      break if resource_pool.config.memory_allocation.reservation == memory_reservation && resource_pool.config.memory_allocation.expandable_reservation == expandable_reservation
-      refresh_attempts += 1
-      sleep 2
+    if ($vc_version == "6.5")
+      cpi.logger.info("Running against v6.5, sleeping 60 seconds to ensure resource pool setting propagates.")
+      sleep(60)
     end
   end
 

--- a/src/vsphere_cpi/spec/support/lifecycle_helpers.rb
+++ b/src/vsphere_cpi/spec/support/lifecycle_helpers.rb
@@ -652,7 +652,7 @@ module LifecycleHelpers
 
     if ($vc_version == "6.5")
       cpi.logger.info("Running against v6.5, sleeping 60 seconds to ensure resource pool setting propagates.")
-      sleep(60)
+      sleep(3)
     end
   end
 


### PR DESCRIPTION
- Sleep 60 seconds when running against vSphere 6.5 to ensure resource pool configuration settings propogate successfully.
- Remove prior failed attempt to allow resource pool settings to propogate.
- We've observed that on vSphere 6.5, it is possible to start a VM in a resource pool despite memory limitations if the VM is started very soon after the memory limits are changed. This causes our tests to fail. It is unlikely this will affect production 6.5 instances as the CPI does not explicitly configure resource pools (instead, a user would do this, presumedly well before BOSH begins to add VMs to the pool).

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Ran lifecycle integration tests
