### PR TITLE
Increase ram to fix 6.5 tests

### DIFF
--- a/src/vsphere_cpi/spec/integration/multi_cluster_overflow_spec.rb
+++ b/src/vsphere_cpi/spec/integration/multi_cluster_overflow_spec.rb
@@ -11,7 +11,7 @@ context 'given 2 clusters with a datastore and a resource pool' do
 
   let(:vm_type) do
     {
-      'ram' => 512,
+      'ram' => 1024,
       'disk' => 2048,
       'cpu' => 1,
       'memory_reservation_locked_to_max' => true,
@@ -36,8 +36,8 @@ context 'given 2 clusters with a datastore and a resource pool' do
 
   context 'when no cluster has enough reservable memory' do
     before do
-      update_resource_pool_memory_reservation(cpi, @first_cluster_name, @first_rp, 100, false)
-      update_resource_pool_memory_reservation(cpi, @second_cluster_name, @second_rp, 100, false)
+      update_resource_pool_memory_reservation(cpi, @first_cluster_name, @first_rp, 700, false)
+      update_resource_pool_memory_reservation(cpi, @second_cluster_name, @second_rp, 700, false)
     end
     after do
       update_resource_pool_memory_reservation(cpi, @first_cluster_name, @first_rp, 1, true)
@@ -61,8 +61,8 @@ context 'given 2 clusters with a datastore and a resource pool' do
 
   context 'when the first cluster has enough reservable memory' do
     before do
-      update_resource_pool_memory_reservation(cpi, @first_cluster_name, @first_rp, 1024, false)
-      update_resource_pool_memory_reservation(cpi, @second_cluster_name, @second_rp, 100, false)
+      update_resource_pool_memory_reservation(cpi, @first_cluster_name, @first_rp, 2048, false)
+      update_resource_pool_memory_reservation(cpi, @second_cluster_name, @second_rp, 700, false)
     end
     after do
       update_resource_pool_memory_reservation(cpi, @first_cluster_name, @first_rp, 1, true)
@@ -92,8 +92,8 @@ context 'given 2 clusters with a datastore and a resource pool' do
 
   context 'when the second cluster has enough reservable memory' do
     before do
-      update_resource_pool_memory_reservation(cpi, @first_cluster_name, @first_rp, 100, false)
-      update_resource_pool_memory_reservation(cpi, @second_cluster_name, @second_rp, 1024, false)
+      update_resource_pool_memory_reservation(cpi, @first_cluster_name, @first_rp, 700, false)
+      update_resource_pool_memory_reservation(cpi, @second_cluster_name, @second_rp, 2048, false)
     end
     after do
       update_resource_pool_memory_reservation(cpi, @first_cluster_name, @first_rp, 1, true)

--- a/src/vsphere_cpi/spec/support/lifecycle_helpers.rb
+++ b/src/vsphere_cpi/spec/support/lifecycle_helpers.rb
@@ -649,11 +649,6 @@ module LifecycleHelpers
     resource_spec.memory_allocation.expandable_reservation = expandable_reservation
 
     resource_pool.update_config(resource_pool_name, resource_spec)
-
-    if ($vc_version == "6.5")
-      cpi.logger.info("Running against v6.5, sleeping 60 seconds to ensure resource pool setting propagates.")
-      sleep(3)
-    end
   end
 
   private


### PR DESCRIPTION
The 6.5 test beds have some weirdness around setting ram to 100 in reservations. It is looking for at least 640 so update_resource_pool_memory_reservation was actually failing and it never tried to create vm and start it up. This bumps it up and it seems to work