### PR TITLE
Only fetch required DVPGs in generate_network_env #183413921

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -777,21 +777,49 @@ module VSphereCloud
         next unless device.kind_of?(Vim::Vm::Device::VirtualEthernetCard)
         v_network_name = case device.backing
           when Vim::Vm::Device::VirtualEthernetCard::DistributedVirtualPortBackingInfo
-            network = @datacenter.mob.network.detect do |n|
-              n.is_a?(VimSdk::Vim::Dvs::DistributedVirtualPortgroup) &&
-                n.config.respond_to?(:backing_type) &&
-                n.config.backing_type == 'nsx' &&
-                n.key == device.backing.port.portgroup_key
-            rescue
-              next  # Skip a network managed object that disappeared on us
+            # If we see DistributedVirtualPortBackingInfo for the device, we're dealing with a cVDS (managed in vsphere):
+
+            # https://kb.vmware.com/s/article/79872#The_reasons_for_running_NSX-T_on_VDS
+            #
+            # With NSX-T 3.0, it is now possible to run NSX-T directly on a VDS (the VDS version must be at least 7.0). 
+            # On ESXi platform, the N-VDS was already sharing its code base with the VDS in the first place, so this 
+            # is not really a change of NSX virtual switch but rather a change of how it is represented in vCenter
+          
+            # In case this is a NSX-T >= 3 backed VDS, we want to filter the networks we fetch from vsphere because
+            # NSX-T may not be used exclusively by vCenter and may have created DVPGs from external sources (e.g via NCP
+            # in kubernetes) 
+            # This can lead to a situation where we potentially find thousands of NSX Logical Switches represented as 
+            # vsphere DVPGs because they're accessible from the DVS so we need to rely on filtering.
+            
+            # Find portgroup that match the portgroup key specified in the device
+            filtered_dvpg = @cloud_searcher.find_resources_by_property_path(@datacenter.mob, 'DistributedVirtualPortgroup', 'key') do |portgroup_key|
+              portgroup_key == device.backing.port.portgroup_key
             end
 
-            if network.nil?
+            # Check if portgroup is backed by NSX-T
+            dvpg = filtered_dvpg.detect do |n|
+              n.config.respond_to?(:backing_type) &&
+                n.config.backing_type == 'nsx'
+            end
+
+            if dvpg.nil?
+              # If we couldn't find an NSX backed DVPG, we're looking at a standard DVPG.
               dvs_index[device.backing.port.portgroup_key]
             else
-              dvs_index[network.config.logical_switch_uuid]
+              # If it is backed by NSX-T we want the logical_switch_uuid. This matches the opaque_network_id on an N-VDS 
+              dvs_index[dvpg.config.logical_switch_uuid]
             end
           when Vim::Vm::Device::VirtualEthernetCard::OpaqueNetworkBackingInfo
+            # If we see OpaqueNetworkBackingInfo for the device, we're dealing with is a NVDS (managed in nsx):
+            # https://kb.vmware.com/s/article/79872#NSX-T_with_N-VDS
+            #
+            # Another reason for decoupling from vSphere was to allow NSX-T to have its own release cycle, 
+            # so that features and bug fixes would be independent of vSphere’s timeline. 
+            # To achieve that feat, the NSX-T virtual switch, the N-VDS, is leveraging an already existing 
+            # software infrastructure that was designed to allow vSphere to consume networking through a 
+            # set of API calls to third party virtual switches. As a result, NSX-T segments are represented 
+            # as “opaque networks”, a name clearly showing that those objects are completely independent 
+            # and unmanageable from vSphere
             dvs_index[device.backing.opaque_network_id]
           else
             PathFinder.new.path(device.backing.network)

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -256,7 +256,33 @@ module VSphereCloud
         let(:dvs_index) { { 'fake_pgkey1' => 'fake_network1' } }
 
         it 'generates the network env' do
+          
           allow(datacenter).to receive_message_chain(:mob, :network, :detect).and_return(nil)
+          allow(cloud_searcher).to receive(:find_resources_by_property_path).and_return([]) 
+          expect(vsphere_cloud.generate_network_env(devices, networks, dvs_index)).to eq(expected_output)
+        end
+      end
+
+      context 'using a NSX on a distributed switch' do
+        let(:opaque_network_id) { 'some_id' }
+        let(:backing) do
+          backing_info = VimSdk::Vim::Vm::Device::VirtualEthernetCard::DistributedVirtualPortBackingInfo.new
+          backing_info.port = double(:port, portgroup_key: 'fake_pgkey1')
+          backing_info
+        end
+        let(:dvpg) do
+          VimSdk::Vim::Dvs::DistributedVirtualPortgroup.new(
+            name: "fake_network1", config: dvpg_config)
+
+        end
+        let(:dvpg_config) { double(:config, backing_type: "nsx", logical_switch_uuid: opaque_network_id) }
+
+        let(:dvs_index) { { opaque_network_id => 'fake_network1' } }
+
+        it 'generates the network env' do
+          allow(datacenter).to receive(:mob)
+          allow(cloud_searcher).to receive(:find_resources_by_property_path).and_return([dvpg]) 
+          allow(dvpg).to receive(:config).and_return(dvpg_config)
           expect(vsphere_cloud.generate_network_env(devices, networks, dvs_index)).to eq(expected_output)
         end
       end


### PR DESCRIPTION
[ #183413921 ]

if we're running on vsphere >= v7 and nsx-t >= v3 and are using NSX-T on vsphere DVS

then

NSX-T will potentially sync thousands of NSX-T logical switches into a DVS in certain conditions (the setup where this was discovered used NCP on Kubernetes within the same VCENTER. NCP and VCENTER shared the NSX-T deployment. NCP created logical switches for every namespace on a cluster leading to thousands of synced DVPGs in VCENTER).

and that caused create_vm to run painfully long since the old code iterated over `datacenter.mob.networks` to find the right DVPG within all network objects in vsphere. Checking all items in the list could take enough time for some items in the list being deleted from NSX before they could be accessed.

We do not need to iterate over all networks since the `device.port.portgroup_key` got populated in create_vm which calls find_network_retryably to properly deal with identifying the right network to use. So it should be safe to use data on the previously configured device to search for just the DVPG we need and (depending on whether the DVPG is created via NSX) use either the nsx switch id or the portgroup_key for `v_network_name`

Update existing tests for extra cloudsearcher calls, add additional test for "synced" DVPGs.


- [x] Bug fix (non-breaking change which fixes an issue)


Tests:
- units
- integration:
-- `bundle exec rspec spec/integration/ --tag ~nvds --tag cvds --tag nsxt_all --tag vsphere_networking` against `vsphere 7` + `nsx 3.1` with cvds networks configured
-- `bundle exec rspec --tag '~cvds' --tag '~disk_migration' --tag '~nsxv' --tag '~host_maintenance' --tag '~nsxt_policy'` against `vsphere 6.5` + `nsx 2.5`