### PR TITLE
Use `ruby-3.1` package which includes Clang

### DIFF
--- a/.final_builds/packages/ruby-3.1/index.yml
+++ b/.final_builds/packages/ruby-3.1/index.yml
@@ -1,0 +1,6 @@
+builds:
+  9ff0c627ab22a33f0c38fcda43304f7f7e634f76ebfeb074dd8c489b52cf5047:
+    version: 9ff0c627ab22a33f0c38fcda43304f7f7e634f76ebfeb074dd8c489b52cf5047
+    blobstore_id: 89fc3fea-4911-4f6f-7648-a6efec83b4c2
+    sha1: sha256:c0074211f571e2510be4a5376925b127936d35fd3f2de364a5577a07f6dc0595
+format-version: "2"

--- a/jobs/vsphere_cpi/spec
+++ b/jobs/vsphere_cpi/spec
@@ -6,10 +6,10 @@ templates:
   cpi.json.erb: config/cpi.json
   nsx_cacert.pem.erb: config/nsx_cacert.pem
   nsxt_cacert.pem.erb: config/nsxt_cacert.pem
-  
+
 packages:
 - iso9660wrap
-- ruby-3.1.2-r0.91.0
+- ruby-3.1
 - vsphere_cpi
 
 properties:

--- a/jobs/vsphere_cpi/templates/cpi.erb
+++ b/jobs/vsphere_cpi/templates/cpi.erb
@@ -32,10 +32,10 @@ export no_proxy="<%= no_proxy %>"
   export NSXT_SKIP_SSL_VERIFY=true
 <% end %>
 
-export PATH=$BOSH_PACKAGES_DIR/ruby-3.1.2-r0.91.0/bin:$BOSH_PACKAGES_DIR/iso9660wrap/bin:$PATH
+export PATH=$BOSH_PACKAGES_DIR/ruby-3.1/bin:$BOSH_PACKAGES_DIR/iso9660wrap/bin:$PATH
 
 export BUNDLE_GEMFILE=$BOSH_PACKAGES_DIR/vsphere_cpi/Gemfile
-bundle_cmd="${BOSH_PACKAGES_DIR}/ruby-3.1.2-r0.91.0/bin/bundle"
+bundle_cmd="${BOSH_PACKAGES_DIR}/ruby-3.1/bin/bundle"
 
 exec $bundle_cmd exec $BOSH_PACKAGES_DIR/vsphere_cpi/bin/vsphere_cpi \
   $BOSH_JOBS_DIR/vsphere_cpi/config/cpi.json

--- a/packages/ruby-3.1.2-r0.91.0/spec.lock
+++ b/packages/ruby-3.1.2-r0.91.0/spec.lock
@@ -1,2 +1,0 @@
-name: ruby-3.1.2-r0.91.0
-fingerprint: 4a7d89622dc38f8f526b36e99c5b8fea7a5aff61941b998b22d1d8eeeeb42dff

--- a/packages/ruby-3.1/spec.lock
+++ b/packages/ruby-3.1/spec.lock
@@ -1,0 +1,2 @@
+name: ruby-3.1
+fingerprint: 9ff0c627ab22a33f0c38fcda43304f7f7e634f76ebfeb074dd8c489b52cf5047

--- a/packages/vsphere_cpi/packaging
+++ b/packages/vsphere_cpi/packaging
@@ -3,7 +3,7 @@
 set -e
 
 BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
-source ${BOSH_PACKAGES_DIR}/ruby-3.1.2-r0.91.0/bosh/compile.env
+source ${BOSH_PACKAGES_DIR}/ruby-3.1/bosh/compile.env
 
 
 cp -a vsphere_cpi/* ${BOSH_INSTALL_TARGET}

--- a/packages/vsphere_cpi/spec
+++ b/packages/vsphere_cpi/spec
@@ -1,7 +1,7 @@
 ---
 name: vsphere_cpi
 dependencies:
-- ruby-3.1.2-r0.91.0
+- ruby-3.1
 files:
 - vsphere_cpi/Gemfile
 - vsphere_cpi/Gemfile.lock


### PR DESCRIPTION
Previously, the CPI used the old ruby-3.1.2-r0.91.0 package to avoid package collision with the BOSH Director. This had several drawbacks, especially that it was difficult to autobump and had poor performance on Jammy.

This commit addresses both shortcomings by switching to using the newer, more easily autobump-able ruby-3.1 package, which also includes the ability to build with the Clang compiler instead of the GCC compiler.

The Clang compiler generates a smaller, faster Ruby than GCC on Jammy stemcells.

Specifically, the thread memory footprint is much smaller, from our notes:

- Jammy w/ GCC: 21688 initial, 32156 after thread, 32156 after finish, around 1MB per Thread.new call
- Jammy w/ Clang: 13932 initial, 14012 after thread, 14208 after finish, between 8KB and 28KB per Thread.new call