### PR TITLE
expose vmx_options.disk.enableUUID globally

### DIFF
--- a/jobs/vsphere_cpi/spec
+++ b/jobs/vsphere_cpi/spec
@@ -77,6 +77,9 @@ properties:
       -----BEGIN CERTIFICATE-----
       MII...
       -----END CERTIFICATE-----
+  vcenter.vmx_options.disk.enableUUID:
+    description: Enable usage of Disk UUIDs for partition lookups of the bosh agent. This is required for Kubernetes Clusters deployed by Bosh to use the Kubernetes CPI (e.g. to provision Pod Volumes). Adds labels to scsi disk devices so the disk device path (`/dev/sd*`) can be discovered via Linux OS. See https://help.ubuntu.com/community/UsingUUID.
+    example: 1 # Allowed values 0 || 1 || "0" || "1"
   vcenter.nsxt.default_vif_type:
     description: "Default vif_type for logical port attachment. Supported types: PARENT."
   vcenter.nsxt.use_policy_api:

--- a/jobs/vsphere_cpi/templates/cpi.json.erb
+++ b/jobs/vsphere_cpi/templates/cpi.json.erb
@@ -77,6 +77,12 @@
     end
   end
 
+  if_p('vcenter.vmx_options.disk.enableUUID') do
+    vcenter = params['cloud']['properties']['vcenters'].first
+    vcenter['vmx_options'] = {} if vcenter['vmx_options'].nil?
+    vcenter['vmx_options']['disk'] = p('vcenter.vmx_options.disk')
+  end
+
   if_p('vcenter.nsx.address') do
     vcenter = params['cloud']['properties']['vcenters'].first
     vcenter['nsx'] = {

--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -846,7 +846,8 @@ module VSphereCloud
       # When disk.enableUUID is true on the vmx options, consistent volume IDs are requested, and we can use them
       # to ensure the precise ephemeral volume is mounted.   This is mandatory for
       # cases where multiple SCSI controllers are present on the VM, as is common with Kubernetes VMs.
-      if vm_config.vmx_options['disk.enableUUID'] == "1"
+      enableUUID = vm_config.vmx_options['disk.enableUUID'] || @config.disk_enable_uuid || 0
+      if enableUUID == "1" || enableUUID == 1
         logger.info("Using ephemeral disk UUID #{ephemeral_disk.backing.uuid.downcase}")
         {
           'system' => system_disk.unit_number.to_s,

--- a/src/vsphere_cpi/lib/cloud/vsphere/config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/config.rb
@@ -244,6 +244,10 @@ module VSphereCloud
       vcenter['memory_reservation_locked_to_max']
     end
 
+    def disk_enable_uuid
+      vcenter['disk']['enableUUID']
+    end
+
     private
 
     attr_reader :config
@@ -276,6 +280,11 @@ module VSphereCloud
             optional('upgrade_hw_version') => bool,
             optional('memory_reservation_locked_to_max') => bool,
             optional('vm_storage_policy_name') => String,
+            optional('vmx_options') => {
+              optional('disk') => {
+                optional('enableUUID') => Integer
+              }
+            },
             optional('nsxt') => {
               optional('host') => String,
               optional('username') => String,

--- a/src/vsphere_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/vsphere_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -114,7 +114,39 @@ describe 'cpi.json.erb' do
       }
     })
   end
+  context 'when vcenter.vmx_options.disk.enableUUID is set globally' do
+    let(:datastore_pattern) { nil }
+    let(:datastore_cluster_pattern) { nil }
+    let(:persistent_datastore_pattern) { nil }
+    let(:persistent_datastore_cluster_pattern) { nil }
+    before(:each) do
 
+      manifest['properties']['vcenter']['vmx_options'] = { 'disk' => { 'enableUUID' => 1 } }
+    end
+
+    it 'renders the property' do
+      subject['cloud']['properties']['vcenters'].each do |vcenter|
+        expect(vcenter['vmx_options']).to eq(
+          { 'disk' => { 'enableUUID' => 1 } }
+        )
+      end
+    end
+
+    it 'does not render the optional properties' do
+      expect(subject['cloud']['properties']['vcenters'].first['datacenters'].first).to eq(
+        {
+          'allow_mixed_datastores' => true,
+          'clusters' => [
+            'cluster-1'
+          ],
+          'disk_path' => 'disk-path',
+          'name' => 'datacenter-1',
+          'template_folder' => 'template-folder',
+          'vm_folder' => 'vm-folder'
+        }
+      )
+    end
+  end
   context 'when optional datacenter properties are not set' do
     let(:datastore_pattern) { nil }
     let(:datastore_cluster_pattern) { nil }

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -2438,7 +2438,56 @@ module VSphereCloud
           expect(disk_cid).to eq('fake-disk-cid')
         end
       end
-
+      context 'when global vmx_options are set' do
+        let(:vm_config) { instance_double(VmConfig) }
+        let(:system_disk_unit_number) { 1 }
+        let(:system_disk) do
+          instance_double(VimSdk::Vim::Vm::Device::VirtualDisk, unit_number: system_disk_unit_number)
+        end
+        let(:ephemeral_disk_unit_number) { 2 }
+        let(:ephemeral_uuid) { 'TESTGENERATEDISKENV' }
+        let(:ephemeral_backing) do
+          instance_double(VimSdk::Vim::Vm::Device::VirtualDisk::FlatVer2BackingInfo, uuid: ephemeral_uuid)
+        end
+        let(:ephemeral_disk) do
+          instance_double(VimSdk::Vim::Vm::Device::VirtualDisk,
+                          backing: ephemeral_backing,
+                          unit_number: ephemeral_disk_unit_number
+          )
+        end
+        let(:vm_vmx_options) do
+          {
+            'disk.enableUUID' => 0
+          }
+        end
+        context 'when no config was provided on vm level nor global' do
+          it 'uses the global value' do
+            allow(cloud_config).to receive(:disk_enable_uuid).and_return(nil)
+            allow(vm_config).to receive(:vmx_options).and_return({})
+            disk_env = subject.generate_disk_env(system_disk, ephemeral_disk, vm_config)
+            expect(disk_env['ephemeral']).to eq(ephemeral_disk_unit_number.to_s)
+            expect(disk_env['system']).to eq(system_disk_unit_number.to_s)
+          end
+        end
+        context 'when no config was provided on vm level' do
+          it 'uses the global value' do
+            allow(cloud_config).to receive(:disk_enable_uuid).and_return(1)
+            allow(vm_config).to receive(:vmx_options).and_return({})
+            disk_env = subject.generate_disk_env(system_disk, ephemeral_disk, vm_config)
+            expect(disk_env['ephemeral']). to eq({'id' => ephemeral_uuid.downcase})
+            expect(disk_env['system']).to eq(system_disk_unit_number.to_s)
+          end
+        end
+        context 'when vm_options override global vmx_options' do
+          it 'uses the vm_options value' do
+            allow(cloud_config).to receive(:disk_enable_uuid).and_return(1)
+            allow(vm_config).to receive(:vmx_options).and_return(vm_vmx_options)
+            disk_env = subject.generate_disk_env(system_disk, ephemeral_disk, vm_config)
+            expect(disk_env['ephemeral']).to eq(ephemeral_disk_unit_number.to_s)
+            expect(disk_env['system']).to eq(system_disk_unit_number.to_s)
+          end
+        end
+      end
       context 'when both global default_disk_type is set and disk_pool type is set' do
         let(:default_disk_type) { 'fake-global-type' }
         it 'create disk with the specified disk_pool type' do


### PR DESCRIPTION
operators may choose to expose this setting globally instead of adding it to all vm_types in cloud config.

why:

As an operator who mainly deploys kubernetes clusters that use the kubernetes vsphere container storage plugin, I do not wan't to set the disk.enableUUID flag on a per vm_type basis. I want to enable this globally.

adds test for behaviour when the options is set on cpi and vm level. VM level settings take precedence over cpi level settings.

the config itself is optional and only rendered in if required.