### PR TITLE
Remove blobstore info from IaaS metadata endpoints

### DIFF
--- a/jobs/vsphere_cpi/spec
+++ b/jobs/vsphere_cpi/spec
@@ -99,71 +99,10 @@ properties:
     default:
       - 0.pool.ntp.org
       - 1.pool.ntp.org
-  agent.blobstore.access_key_id:
-    description: AWS access_key_id for agent used by s3 blobstore plugin
-  agent.blobstore.secret_access_key:
-    description: AWS secret_access_key for agent used by s3 blobstore plugin
   agent.mbus:
     description: Agent mbus
   agent.nats.address:
     description: Address of the nats server
-  agent.blobstore.address:
-    description: Address for agent to connect to blobstore server used by dav blobstore plugin
-  agent.blobstore.use_ssl:
-    description: Whether the agent blobstore plugin should use SSL to connect to the blobstore server
-  agent.blobstore.s3_region:
-    description: AWS region used by s3 blobstore plugin
-  agent.blobstore.s3_port:
-    description: Port of agent blobstore server used by s3 blobstore plugin
-  agent.blobstore.host:
-    description: Host of agent blobstore server used by s3 blobstore plugin
-  agent.blobstore.s3_force_path_style:
-    description: Whether the agent blobstore plugin will always use path style for bucket access
-  agent.blobstore.ssl_verify_peer:
-    description: Whether the agent blobstore plugin should verify its peer when using SSL
-  agent.blobstore.s3_multipart_threshold:
-    description: Agent blobstore threshold for multipart uploads
-  agent.blobstore.s3_signature_version:
-    description: Signature version used to connect to an s3 blobstore
-  blobstore.provider:
-    description: Provider of the blobstore used by director and agent (dav|local|s3)
-    default: 'dav'
-  blobstore.bucket_name:
-    description: AWS S3 Bucket used by s3 blobstore plugin
-  blobstore.access_key_id:
-    description: AWS access_key_id used by s3 blobstore plugin
-  blobstore.secret_access_key:
-    description: AWS secret_access_key used by s3 blobstore plugin
-  blobstore.use_ssl:
-    description: Whether the s3 blobstore plugin should use SSL to connect to the blobstore server
-    default: true
-  blobstore.s3_region:
-    description: AWS region used by s3 blobstore plugin
-  blobstore.s3_port:
-    description: Port of blobstore server used by s3 blobstore plugin
-    default: 443
-  blobstore.host:
-    description: Host of blobstore server used by s3 blobstore plugin
-  blobstore.s3_force_path_style:
-    description: Whether s3 blobstore plugin will always use path style for bucket access
-    default: false
-  blobstore.ssl_verify_peer:
-    description: Whether the s3 blobstore plugin should verify its peer when using SSL
-  blobstore.s3_multipart_threshold:
-    description: s3 blobstore threshold for multipart uploads
-  blobstore.path:
-    description: local blobstore path
-  blobstore.address:
-    description: Address of blobstore server used by dav blobstore plugin
-  blobstore.port:
-    description: Port of blobstore server used by dav blobstore plugin
-    default: 25250
-  blobstore.s3_signature_version:
-    description: Signature version used to connect to an s3 blobstore
-  blobstore.agent.user:
-    description: Username agent uses to connect to blobstore used by dav blobstore plugin
-  blobstore.agent.password:
-    description: Password agent uses to connect to blobstore used by dav blobstore plugin
   nats.user:
     description: Username to connect to nats with
     default: nats

--- a/jobs/vsphere_cpi/templates/cpi.json.erb
+++ b/jobs/vsphere_cpi/templates/cpi.json.erb
@@ -131,46 +131,6 @@
     end
   end
 
-  if_p('blobstore') do
-    if p('blobstore.provider') == "s3"
-      options = {
-        "bucket_name" => p('blobstore.bucket_name'),
-        "access_key_id" => p(['agent.blobstore.access_key_id', 'blobstore.access_key_id']),
-        "secret_access_key" => p(['agent.blobstore.secret_access_key', 'blobstore.secret_access_key'])
-      }
-
-      def update_blobstore_options(options, manifest_key, rendered_key=manifest_key)
-        value = p(["agent.blobstore.#{manifest_key}", "blobstore.#{manifest_key}"], nil)
-        options[rendered_key] = value unless value.nil?
-      end
-
-      update_blobstore_options(options, 'use_ssl')
-      update_blobstore_options(options, 's3_port', 'port')
-      update_blobstore_options(options, 'host')
-      update_blobstore_options(options, 's3_force_path_style')
-      update_blobstore_options(options, 'ssl_verify_peer')
-      update_blobstore_options(options, 's3_multipart_threshold')
-      update_blobstore_options(options, 's3_signature_version', 'signature_version')
-      update_blobstore_options(options, 's3_region', 'region')
-
-    elsif p('blobstore.provider') == 'local'
-      options = {
-        "blobstore_path" => p('blobstore.path')
-      }
-    else
-      options = {
-        "endpoint" => "http://#{p(['agent.blobstore.address', 'blobstore.address'])}:#{p('blobstore.port')}",
-        "user" => p('blobstore.agent.user'),
-        "password" => p('blobstore.agent.password')
-      }
-    end
-
-    params["cloud"]["properties"]["agent"]["blobstore"] = {
-      "provider" => p('blobstore.provider'),
-      "options" => options
-    }
-  end
-
   if_p('agent.mbus') do |mbus|
     params["cloud"]["properties"]["agent"]["mbus"] = mbus
   end.else_if_p('nats') do


### PR DESCRIPTION
The BOSH agent reads its blobstore settings from the metadata API endpoint (or equivalent) for its VM within the IaaS. If the blobstore settings are not set in the `env.bosh.blobstores` property, it will fallback to the top-level `blobstore` property in the metadata.

However, in modern configurations, the Director always sends the blobstore settings as part of the environment hash. Additionally, the Director does redaction of credentials in the environment hash when the signed URLs blobstore feature is enabled. This redaction is not applied to the top-level `blobstore` property in the metadata because that is generated solely by the CPI.

Rather than updating each CPI to know about the signed URL feature, we are instead removing the `blobstore` properties from the CPI. This will ensure that Director is the sole point of contact when configuring agent blobstore settings, and ensure that they are always properly redacted.
