### PR TITLE
Allow datastore clusters to be nested in folders

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/storage_pod.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/storage_pod.rb
@@ -37,12 +37,6 @@ module VSphereCloud
         mob.pod_storage_drs_entry.storage_drs_config.pod_config.enabled
       end
 
-      def self.find(name, datacenter_name, client)
-        datacenter_mob = client.find_by_inventory_path(datacenter_name)
-        raise "Datacenter '#{datacenter_name}' not found." unless datacenter_mob
-        self.find_storage_pod(name, datacenter_mob)
-      end
-
       def self.find_storage_pod(name, datacenter_mob)
         datastore_clusters =  datacenter_mob.datastore_folder.child_entity.select {|ce| ce.class == VimSdk::Vim::StoragePod}
         datastore_cluster = datastore_clusters.select { |sp| sp.name == name }.first

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/storage_pod_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/storage_pod_spec.rb
@@ -114,22 +114,28 @@ describe VSphereCloud::Resources::StoragePod do
       storage_pod =  described_class.find_storage_pod(storage_pod_name, datacenter)
       expect(storage_pod).to be_a(VSphereCloud::Resources::StoragePod)
     end
+
+    context 'when storage_pod is nested in folders' do
+      let(:top_level_pod) {instance_double(VimSdk::Vim::StoragePod, name: 'the_pod', class: VimSdk::Vim::StoragePod)}
+      let(:other_folder) { instance_double(VimSdk::Vim::Folder, name: 'other-top-level-folder', class: VimSdk::Vim::Folder) }
+      let(:folder) { instance_double(VimSdk::Vim::Folder, name: 'top-level-folder', child_entity: [nested_folder], class: VimSdk::Vim::Folder) }
+      let(:nested_folder) { instance_double(VimSdk::Vim::Folder, name: 'nested-folder', child_entity: [nested_pod], class: VimSdk::Vim::Folder) }
+      let(:nested_pod) {instance_double(VimSdk::Vim::StoragePod, name: 'the_pod', class: VimSdk::Vim::StoragePod)}
+      let(:datastore_folder) { instance_double(VimSdk::Vim::Folder, child_entity: [top_level_pod, other_folder, folder], class: VimSdk::Vim::Folder)}
+
+      it 'returns the correct storage pod' do
+        expect(described_class.find_storage_pod('top-level-folder/nested-folder/the_pod', datacenter).mob).to eq(nested_pod)
+      end
+    end
   end
 
   describe '.search_storage_pods' do
-    let(:datacenter) { double('VimSdk::Vim::Datacenter')}
-    let(:datastore_folder) { double('datastore_folder')}
+    let(:datacenter) { double('VimSdk::Vim::Datacenter', datastore_folder: datastore_folder)}
+    let(:datastore_folder) { double('datastore_folder', child_entity: [storage_pod1, storage_pod2])}
     let(:storage_pod_name1) {'cpi-sp1'}
     let(:storage_pod_name2) {'cpi-sp2'}
-    let(:storage_pod1) {instance_double('VimSdk::Vim::StoragePod', name: storage_pod_name1)}
-    let(:storage_pod2) {instance_double('VimSdk::Vim::StoragePod', name: storage_pod_name2)}
-
-    before do
-      allow(datacenter).to receive(:datastore_folder).and_return(datastore_folder)
-      expect(datastore_folder).to receive(:child_entity).and_return([storage_pod1, storage_pod2])
-      allow(storage_pod1).to receive(:class).and_return(VimSdk::Vim::StoragePod)
-      allow(storage_pod2).to receive(:class).and_return(VimSdk::Vim::StoragePod)
-    end
+    let(:storage_pod1) {instance_double('VimSdk::Vim::StoragePod', name: storage_pod_name1, class: VimSdk::Vim::StoragePod)}
+    let(:storage_pod2) {instance_double('VimSdk::Vim::StoragePod', name: storage_pod_name2, class: VimSdk::Vim::StoragePod)}
 
     it 'returns empty if nothing matches' do
       storage_pods = described_class.search_storage_pods(/foo/, datacenter)
@@ -145,6 +151,25 @@ describe VSphereCloud::Resources::StoragePod do
     it 'returns all the pods when searching with a broad expression' do
       storage_pods =  described_class.search_storage_pods(/.*/, datacenter)
       expect(storage_pods.count).to eq 2
+    end
+
+    context 'when storage_pod is nested in folders' do
+      let(:top_level_pod) {instance_double(VimSdk::Vim::StoragePod, name: 'the_pod', class: VimSdk::Vim::StoragePod)}
+      let(:other_folder) { instance_double(VimSdk::Vim::Folder, name: 'other-top-level-folder', class: VimSdk::Vim::Folder) }
+      let(:folder) { instance_double(VimSdk::Vim::Folder, name: 'top-level-folder', child_entity: [nested_folder, other_nested_folder], class: VimSdk::Vim::Folder) }
+      let(:nested_folder) { instance_double(VimSdk::Vim::Folder, name: 'nested-folder', child_entity: [nested_pod1, nested_pod2, nested_pod3], class: VimSdk::Vim::Folder) }
+      let(:other_nested_folder) { instance_double(VimSdk::Vim::Folder, name: 'other-nested-folder', child_entity: [nested_pod4], class: VimSdk::Vim::Folder) }
+      let(:nested_pod1) {instance_double(VimSdk::Vim::StoragePod, name: 'the_pod_one', class: VimSdk::Vim::StoragePod)}
+      let(:nested_pod2) {instance_double(VimSdk::Vim::StoragePod, name: 'the_pod_two', class: VimSdk::Vim::StoragePod)}
+      let(:nested_pod3) {instance_double(VimSdk::Vim::StoragePod, name: 'something_else', class: VimSdk::Vim::StoragePod)}
+      let(:nested_pod4) {instance_double(VimSdk::Vim::StoragePod, name: 'the_pod_four', class: VimSdk::Vim::StoragePod)}
+      let(:datastore_folder) { instance_double(VimSdk::Vim::Folder, child_entity: [top_level_pod, other_folder, folder], class: VimSdk::Vim::Folder)}
+
+      it 'returns all matching storage pods' do
+        pods = described_class.search_storage_pods('top-level-folder/(other-)?nested-folder/the_pod.*', datacenter)
+        mobs = pods.collect &:mob
+        expect(mobs).to eq([nested_pod1, nested_pod2, nested_pod4])
+      end
     end
   end
 end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/storage_pod_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/storage_pod_spec.rb
@@ -91,43 +91,6 @@ describe VSphereCloud::Resources::StoragePod do
     end
   end
 
-  describe '.find' do
-    let(:datacenter) { double('VimSdk::Vim::Datacenter')}
-    let(:datastore_folder) { double('datastore_folder')}
-    let(:client) { double('VSphereCloud::VCenterClient') }
-    let(:storage_pod_name) {'cpi-sp1'}
-    let(:storage_pod) {instance_double('VimSdk::Vim::StoragePod', name: storage_pod_name)}
-    context 'with non-existent datacenter' do
-      it 'raises an error' do
-        allow(client).to receive(:find_by_inventory_path).with('dc1').and_return(nil)
-        expect {
-          described_class.find(storage_pod_name, 'dc1', client)
-        }.to raise_error /Datacenter 'dc1' not found/
-      end
-    end
-
-    context 'with valid datacenter' do
-      before do
-        expect(client).to receive(:find_by_inventory_path).with('dc1').and_return(datacenter)
-        allow(datacenter).to receive(:datastore_folder).and_return(datastore_folder)
-      end
-
-      it 'raises an error if storage_pod is not found' do
-        expect(datastore_folder).to receive(:child_entity).and_return([])
-        expect {
-          described_class.find(storage_pod_name, 'dc1', client)
-        }.to raise_error /Datastore Cluster with name: 'cpi-sp1' not found/
-      end
-
-      it 'returns an instance of Resources::StoragePod when storage_pod if found' do
-        expect(datastore_folder).to receive(:child_entity).and_return([storage_pod])
-        allow(storage_pod).to receive(:class).and_return(VimSdk::Vim::StoragePod)
-        storage_pod = described_class.find(storage_pod_name, 'dc1', client)
-        expect(storage_pod).to be_a(VSphereCloud::Resources::StoragePod)
-      end
-    end
-  end
-
   describe '.find_storage_pod' do
     let(:datacenter) { double('VimSdk::Vim::Datacenter')}
     let(:datastore_folder) { double('datastore_folder')}


### PR DESCRIPTION
Currently datastore clusters must be top level for the cpi to find them, this change will add functionality to search for them within storage folders in vcenter.

Slashes are not valid in folder or datastore cluster names, they must be escaped in vCenter, so we use slash as our expected folder delimiter.

For the "pattern" matching case, after splitting on slashes, we have to convert each segment into a regular expression in case the user is relying on that for wildcard matching. As regexes don't use forward slashes, and the entity names they are searching for also can't have slashes, this should be safe.

The unused StoragePod.find method was also removed