### PR TITLE
offline fix; disable checks and set install to be local too

### DIFF
--- a/packages/vsphere_cpi/packaging
+++ b/packages/vsphere_cpi/packaging
@@ -11,9 +11,11 @@ cp -a vsphere_cpi/* ${BOSH_INSTALL_TARGET}
 cd ${BOSH_INSTALL_TARGET}
 
 export BUNDLER_VERSION="$(bundle -v | grep -o -e '[0-9.]*')"
+bundle config set --local disable_version_check 'true'
+bundle config set --local disable_checksum_validation 'true'
 bundle config set --local deployment 'true'
 bundle config set --local no_prune 'true'
 bundle config set --local without 'development test'
 bundle config set --local cache_path 'vendor/package'
 
-bundle install
+bundle install --local


### PR DESCRIPTION
# Description

This fixes offline deployment of vsphere-cpi

## Related PR and Issues
Fixes #366 

## Impacted Areas in Application
List general components of the application that this PR will affect:

packaging script

## Type of change

Adding more config for bundler to have it truly offline

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] 
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Deployed offline and it worked

**Test Configuration**:
* Environment Variables for Integration test:
* Hardware Requirements in ESXi:
* Toolchain:
* SDK:

# Checklist:

- [X] My code follows the standard ruby style guide
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
