### PR TITLE
Fix TLS verification with multiple CPI configs

### DIFF
--- a/ci/config.rb
+++ b/ci/config.rb
@@ -7,7 +7,6 @@ $pipeline.pool('6.5-nsxt25') do |pool|
       '--tag ~host_maintenance',
       '--tag ~nsxt_policy',
     ].join(' '),
-    NSXT_SKIP_SSL_VERIFY: "true"
   }
 end
 
@@ -19,7 +18,6 @@ $pipeline.pool('6.7-nsxt25') do |pool|
       '--tag ~host_maintenance',
       '--tag ~nsxt_policy',
     ].join(' '),
-    NSXT_SKIP_SSL_VERIFY: "true"
   }
 end
 
@@ -51,7 +49,6 @@ $pipeline.pool('7.0-nsxt31-cvds') do |pool|
       '--tag nsxt_all',
       '--tag vsphere_networking',
     ].join(' '),
-    NSXT_SKIP_SSL_VERIFY: "true",
   }
 end
 

--- a/jobs/vsphere_cpi/spec
+++ b/jobs/vsphere_cpi/spec
@@ -1,7 +1,6 @@
 ---
 name: vsphere_cpi
 templates:
-  cacert.pem.erb: config/cacert.pem
   cpi.erb: bin/cpi
   cpi.json.erb: config/cpi.json
   nsx_cacert.pem.erb: config/nsx_cacert.pem

--- a/jobs/vsphere_cpi/spec
+++ b/jobs/vsphere_cpi/spec
@@ -3,8 +3,6 @@ name: vsphere_cpi
 templates:
   cpi.erb: bin/cpi
   cpi.json.erb: config/cpi.json
-  nsx_cacert.pem.erb: config/nsx_cacert.pem
-  nsxt_cacert.pem.erb: config/nsxt_cacert.pem
 
 packages:
 - iso9660wrap

--- a/jobs/vsphere_cpi/templates/cacert.pem.erb
+++ b/jobs/vsphere_cpi/templates/cacert.pem.erb
@@ -1,1 +1,0 @@
-<%= p('vcenter.connection_options.ca_cert', '') %>

--- a/jobs/vsphere_cpi/templates/cpi.erb
+++ b/jobs/vsphere_cpi/templates/cpi.erb
@@ -20,9 +20,6 @@ export NO_PROXY="<%= no_proxy %>"
 export no_proxy="<%= no_proxy %>"
 <% end %>
 
-<% if_p('vcenter.connection_options.ca_cert') do %>
-  export BOSH_CA_CERT_FILE=$BOSH_JOBS_DIR/vsphere_cpi/config/cacert.pem
-<% end %>
 <% if_p('vcenter.nsx.ca_cert') do %>
   export BOSH_NSX_CA_CERT_FILE=$BOSH_JOBS_DIR/vsphere_cpi/config/nsx_cacert.pem
 <% end %>

--- a/jobs/vsphere_cpi/templates/cpi.erb
+++ b/jobs/vsphere_cpi/templates/cpi.erb
@@ -20,9 +20,6 @@ export NO_PROXY="<%= no_proxy %>"
 export no_proxy="<%= no_proxy %>"
 <% end %>
 
-<% if_p('vcenter.nsx.ca_cert') do %>
-  export BOSH_NSX_CA_CERT_FILE=$BOSH_JOBS_DIR/vsphere_cpi/config/nsx_cacert.pem
-<% end %>
 <% if p('vcenter.nsxt.ca_cert', false) %>
   export BOSH_NSXT_CA_CERT_FILE=$BOSH_JOBS_DIR/vsphere_cpi/config/nsxt_cacert.pem
 <% else %>

--- a/jobs/vsphere_cpi/templates/cpi.erb
+++ b/jobs/vsphere_cpi/templates/cpi.erb
@@ -20,9 +20,7 @@ export NO_PROXY="<%= no_proxy %>"
 export no_proxy="<%= no_proxy %>"
 <% end %>
 
-<% if p('vcenter.nsxt.ca_cert', false) %>
-  export BOSH_NSXT_CA_CERT_FILE=$BOSH_JOBS_DIR/vsphere_cpi/config/nsxt_cacert.pem
-<% else %>
+<% if !p('vcenter.nsxt.ca_cert', false) %>
   export NSXT_SKIP_SSL_VERIFY=true
 <% end %>
 

--- a/jobs/vsphere_cpi/templates/cpi.erb
+++ b/jobs/vsphere_cpi/templates/cpi.erb
@@ -20,10 +20,6 @@ export NO_PROXY="<%= no_proxy %>"
 export no_proxy="<%= no_proxy %>"
 <% end %>
 
-<% if !p('vcenter.nsxt.ca_cert', false) %>
-  export NSXT_SKIP_SSL_VERIFY=true
-<% end %>
-
 export PATH=$BOSH_PACKAGES_DIR/ruby-3.1/bin:$BOSH_PACKAGES_DIR/iso9660wrap/bin:$PATH
 
 export BUNDLE_GEMFILE=$BOSH_PACKAGES_DIR/vsphere_cpi/Gemfile

--- a/jobs/vsphere_cpi/templates/cpi.json.erb
+++ b/jobs/vsphere_cpi/templates/cpi.json.erb
@@ -90,6 +90,7 @@
       'address' => p('vcenter.nsx.address'),
       'user' => p('vcenter.nsx.user'),
       'password' => p('vcenter.nsx.password'),
+      'ca_cert' => p('vcenter.nsx.ca_cert', nil),
     }
   end
 

--- a/jobs/vsphere_cpi/templates/cpi.json.erb
+++ b/jobs/vsphere_cpi/templates/cpi.json.erb
@@ -25,7 +25,8 @@
             "memory_reservation_locked_to_max" => p('vcenter.memory_reservation_locked_to_max'),
             "upgrade_hw_version" => p('vcenter.upgrade_hw_version'),
             "enable_human_readable_name" => p('vcenter.enable_human_readable_name'),
-            "http_logging" => p('vcenter.http_logging')
+            "http_logging" => p('vcenter.http_logging'),
+            "connection_options" => p('vcenter.connection_options')
           }
         ],
         "agent" => {

--- a/jobs/vsphere_cpi/templates/cpi.json.erb
+++ b/jobs/vsphere_cpi/templates/cpi.json.erb
@@ -108,6 +108,9 @@
     if_p('vcenter.nsxt.remote_auth') do
      vcenter['nsxt']['remote_auth'] = p('vcenter.nsxt.remote_auth')
     end
+    if_p('vcenter.nsxt.ca_cert') do
+      vcenter['nsxt']['ca_cert'] = p('vcenter.nsxt.ca_cert')
+    end
 
     if_p('vcenter.nsxt.auth_certificate') do
       vcenter['nsxt']['auth_certificate'] = p('vcenter.nsxt.auth_certificate')

--- a/jobs/vsphere_cpi/templates/nsx_cacert.pem.erb
+++ b/jobs/vsphere_cpi/templates/nsx_cacert.pem.erb
@@ -1,1 +1,0 @@
-<%= p('vcenter.nsx.ca_cert', '') %>

--- a/jobs/vsphere_cpi/templates/nsxt_cacert.pem.erb
+++ b/jobs/vsphere_cpi/templates/nsxt_cacert.pem.erb
@@ -1,1 +1,0 @@
-<%= p('vcenter.nsxt.ca_cert', '') %>

--- a/src/vsphere_cpi/bin/vsphere_cpi
+++ b/src/vsphere_cpi/bin/vsphere_cpi
@@ -69,6 +69,15 @@ cpi_lambda = lambda do |context, _|
     cloud_properties['vcenters'][0]['nsx']['ca_cert_file'] = temp.path
   end
 
+  if cloud_properties['vcenters'][0].fetch('nsxt', {}).fetch('ca_cert', nil)
+    temp = Tempfile.create('vsphere-cpi-nsxt-ca') do |f|
+      f.write(cloud_properties['vcenters'][0]['nsxt']['ca_cert'])
+    end
+
+    temp_certificate_files_to_clean_up << temp
+    cloud_properties['vcenters'][0]['nsxt']['ca_cert_file'] = temp.path
+  end
+
   host = cloud_properties['vcenters'][0]['host']
   connection_options = cloud_properties['vcenters'][0]['connection_options']
   $vc_version = VmodlVersionDiscriminant.retrieve_vmodl_version(

--- a/src/vsphere_cpi/bin/vsphere_cpi
+++ b/src/vsphere_cpi/bin/vsphere_cpi
@@ -40,6 +40,8 @@ cpi_lambda = lambda do |context, _|
     raise "Could not find cloud properties in the configuration"
   end
 
+  temp_certificate_files_to_clean_up = []
+
   cloud_properties = cpi_config['cloud']['properties']
 
   if cloud_properties['vcenters'].nil? || cloud_properties['vcenters'].empty?
@@ -49,9 +51,19 @@ cpi_lambda = lambda do |context, _|
 
   cloud_properties['soap_log'] = soap_log
 
+  if cloud_properties['vcenters'][0].fetch('connection_options', {}).fetch('ca_cert', nil)
+    temp = Tempfile.create('vsphere-cpi-vcenter-ca') do |f|
+      f.write(cloud_properties['vcenters'][0]['connection_options']['ca_cert'])
+    end
+
+    temp_certificate_files_to_clean_up << temp
+    cloud_properties['vcenters'][0]['connection_options']['ca_cert_file'] = temp.path
+  end
+
   host = cloud_properties['vcenters'][0]['host']
+  connection_options = cloud_properties['vcenters'][0]['connection_options']
   $vc_version = VmodlVersionDiscriminant.retrieve_vmodl_version(
-    host, Bosh::Clouds::Config.logger)
+    host, connection_options, Bosh::Clouds::Config.logger)
 
   begin
     cpi_rpc_api_request = JSON.load(cpi_rpc_api_request_raw)
@@ -64,6 +76,10 @@ cpi_lambda = lambda do |context, _|
   rescue JSON::ParserError
     require 'cloud/vsphere'
     Bosh::Clouds::VSphere.new(cloud_properties)
+  ensure
+    temp_certificate_files_to_clean_up.each do |temp_file|
+      temp_file.unlink
+    end
   end
 end
 

--- a/src/vsphere_cpi/bin/vsphere_cpi
+++ b/src/vsphere_cpi/bin/vsphere_cpi
@@ -60,6 +60,15 @@ cpi_lambda = lambda do |context, _|
     cloud_properties['vcenters'][0]['connection_options']['ca_cert_file'] = temp.path
   end
 
+  if cloud_properties['vcenters'][0].fetch('nsx', {}).fetch('ca_cert', nil)
+    temp = Tempfile.create('vsphere-cpi-nsx-ca') do |f|
+      f.write(cloud_properties['vcenters'][0]['nsx']['ca_cert'])
+    end
+
+    temp_certificate_files_to_clean_up << temp
+    cloud_properties['vcenters'][0]['nsx']['ca_cert_file'] = temp.path
+  end
+
   host = cloud_properties['vcenters'][0]['host']
   connection_options = cloud_properties['vcenters'][0]['connection_options']
   $vc_version = VmodlVersionDiscriminant.retrieve_vmodl_version(

--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -29,7 +29,7 @@ module VSphereCloud
     attr_reader :config, :datacenter, :heartbeat_thread, :pbm
 
     def enable_telemetry
-      http_client = VSphereCloud::CpiHttpClient.new
+      http_client = VSphereCloud::CpiHttpClient.new(connection_options: @config.vcenter_connection_options)
       other_client = VCenterClient.new(
         vcenter_api_uri: @config.vcenter_api_uri,
         http_client: http_client
@@ -76,7 +76,7 @@ module VSphereCloud
         Logger.logger.set_request_id(request_id)
       end
 
-      @http_client = VSphereCloud::CpiHttpClient.new(@config.soap_log)
+      @http_client = VSphereCloud::CpiHttpClient.new(connection_options: @config.vcenter_connection_options, http_log: @config.soap_log)
 
       @client = VCenterClient.new(
         vcenter_api_uri: @config.vcenter_api_uri,

--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -928,6 +928,7 @@ module VSphereCloud
       nsx_http_client = NsxHttpClient.new(
         @config.nsx_user,
         @config.nsx_password,
+        @config.nsx_ca_cert_file,
         @config.soap_log,
       )
       @nsx = NSX.new(@config.nsx_url, nsx_http_client)

--- a/src/vsphere_cpi/lib/cloud/vsphere/config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/config.rb
@@ -1,5 +1,5 @@
 module VSphereCloud
-  class NSXTConfig < Struct.new(:host, :username, :password, :remote_auth, :auth_certificate, :auth_private_key, :default_vif_type, :use_policy_api, :policy_api_migration_mode, :allow_overwrite)
+  class NSXTConfig < Struct.new(:host, :username, :password, :ca_cert_file, :remote_auth, :auth_certificate, :auth_private_key, :default_vif_type, :use_policy_api, :policy_api_migration_mode, :allow_overwrite)
     def self.validate_schema(config)
       return true if config.nil?
 
@@ -232,6 +232,7 @@ module VSphereCloud
         vcenter['nsxt']['host'],
         vcenter['nsxt']['username'],
         vcenter['nsxt']['password'],
+        vcenter['nsxt']['ca_cert_file'],
         vcenter['nsxt']['remote_auth'],
         vcenter['nsxt']['auth_certificate'],
         vcenter['nsxt']['auth_private_key'],

--- a/src/vsphere_cpi/lib/cloud/vsphere/config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/config.rb
@@ -218,6 +218,10 @@ module VSphereCloud
       vcenter['nsx']['password']
     end
 
+    def nsx_ca_cert_file
+      vcenter['nsx']['ca_cert_file']
+    end
+
     def upgrade_hw_version
       vcenter['upgrade_hw_version']
     end

--- a/src/vsphere_cpi/lib/cloud/vsphere/config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/config.rb
@@ -157,6 +157,10 @@ module VSphereCloud
       vcenter['enable_auto_anti_affinity_drs_rules']
     end
 
+    def vcenter_connection_options
+      vcenter['connection_options'] || {}
+    end
+
     def datacenter_name
       vcenter_datacenter['name']
     end

--- a/src/vsphere_cpi/lib/cloud/vsphere/cpi_http_client.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cpi_http_client.rb
@@ -3,11 +3,11 @@ require 'cloud/vsphere/base_http_client'
 module VSphereCloud
   class CpiHttpClient < BaseHttpClient
 
-    def initialize(http_log = nil)
+    def initialize(connection_options: {}, http_log: nil)
       # skip SSL verification for backwards compatibility
       super(
         http_log: http_log,
-        trusted_ca_file: ENV['BOSH_CA_CERT_FILE'],
+        trusted_ca_file: connection_options['ca_cert_file'],
         ca_cert_manifest_key: 'vcenter.connection_options.ca_cert',
         skip_ssl_verify: true,
       )

--- a/src/vsphere_cpi/lib/cloud/vsphere/nsx_http_client.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsx_http_client.rb
@@ -1,10 +1,10 @@
 module VSphereCloud
   class NsxHttpClient < BaseHttpClient
-    def initialize(user, password, http_log = nil)
+    def initialize(user, password, ca_cert_file, http_log = nil)
       unless ENV['NSXT_SKIP_SSL_VERIFY'] then
         super(
           http_log: http_log,
-          trusted_ca_file: ENV['BOSH_NSX_CA_CERT_FILE'],
+          trusted_ca_file: ca_cert_file,
           ca_cert_manifest_key: 'vcenter.nsx.ca_cert',
           skip_ssl_verify: false
         )

--- a/src/vsphere_cpi/lib/cloud/vsphere/nsx_http_client.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsx_http_client.rb
@@ -1,17 +1,17 @@
 module VSphereCloud
   class NsxHttpClient < BaseHttpClient
     def initialize(user, password, ca_cert_file, http_log = nil)
-      unless ENV['NSXT_SKIP_SSL_VERIFY'] then
+      if ca_cert_file.nil?
+        super(
+          http_log: http_log,
+          skip_ssl_verify: true
+        )
+      else
         super(
           http_log: http_log,
           trusted_ca_file: ca_cert_file,
           ca_cert_manifest_key: 'vcenter.nsx.ca_cert',
           skip_ssl_verify: false
-        )
-      else
-        super(
-          http_log: http_log,
-          skip_ssl_verify: true
         )
       end
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_api_client_builder.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_api_client_builder.rb
@@ -31,9 +31,7 @@ module VSphereCloud
       end
 
       # Root CA Cert
-      if ENV['BOSH_NSXT_CA_CERT_FILE']
-        configuration.ssl_ca_cert = ENV['BOSH_NSXT_CA_CERT_FILE']
-      end
+      configuration.ssl_ca_cert = @config.ca_cert_file
 
       # SKIP SSL VALIDATION?
       if ENV['NSXT_SKIP_SSL_VERIFY']

--- a/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_api_client_builder.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_api_client_builder.rb
@@ -34,10 +34,9 @@ module VSphereCloud
       configuration.ssl_ca_cert = @config.ca_cert_file
 
       # SKIP SSL VALIDATION?
-      if ENV['NSXT_SKIP_SSL_VERIFY']
-        configuration.verify_ssl = false
-        configuration.verify_ssl_host = false
-      end
+      configuration.verify_ssl = !@config.ca_cert_file.nil?
+      configuration.verify_ssl_host = !@config.ca_cert_file.nil?
+
       @client = NSXT::ApiClient.new(configuration)
       #Design here isn't ideal but allows us to keep "x-allow-overwrite" switching logic out of Swagger generated code.
       if @config.allow_overwrite?

--- a/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_policy_api_client_builder.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_policy_api_client_builder.rb
@@ -24,9 +24,7 @@ module VSphereCloud
       end
 
       # Root CA Cert
-      if ENV['BOSH_NSXT_CA_CERT_FILE']
-        configuration.ssl_ca_cert = ENV['BOSH_NSXT_CA_CERT_FILE']
-      end
+      configuration.ssl_ca_cert = @config.ca_cert_file
 
       # SKIP SSL VALIDATION?
       if ENV['NSXT_SKIP_SSL_VERIFY']

--- a/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_policy_api_client_builder.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsxt_helpers/nsxt_policy_api_client_builder.rb
@@ -27,10 +27,9 @@ module VSphereCloud
       configuration.ssl_ca_cert = @config.ca_cert_file
 
       # SKIP SSL VALIDATION?
-      if ENV['NSXT_SKIP_SSL_VERIFY']
-        configuration.verify_ssl = false
-        configuration.verify_ssl_host = false
-      end
+      configuration.verify_ssl = !@config.ca_cert_file.nil?
+      configuration.verify_ssl_host = !@config.ca_cert_file.nil?
+
       @client = NSXTPolicy::ApiClient.new(configuration)
     end
   end

--- a/src/vsphere_cpi/lib/vmodl_version.rb
+++ b/src/vsphere_cpi/lib/vmodl_version.rb
@@ -14,9 +14,9 @@ module VmodlVersionDiscriminant
   # @param [String] the hostname of the vCenter server
   # @return [String] the usable vSphere management API version as one of "7.0",
   #   "6.7", or "6.5"
-  def self.retrieve_vmodl_version(host, logger = nil)
+  def self.retrieve_vmodl_version(host, connection_options, logger = nil)
     logger.info('Fetching vSphere version to locate SDK') unless logger.nil?
-    http_client = VSphereCloud::CpiHttpClient.new
+    http_client = VSphereCloud::CpiHttpClient.new(connection_options: connection_options)
     url = "https://#{host}/sdk/vimServiceVersions.xml"
 
     body = Bosh::Retryable.new(tries: 3, on: [StandardError]).retryer do

--- a/src/vsphere_cpi/spec/integration/client_spec.rb
+++ b/src/vsphere_cpi/spec/integration/client_spec.rb
@@ -172,7 +172,7 @@ module VSphereCloud
 
       client = VSphereCloud::VCenterClient.new(
         vcenter_api_uri: URI.parse("https://#{host}/sdk/vimService"),
-        http_client: VSphereCloud::CpiHttpClient.new(logger)
+        http_client: VSphereCloud::CpiHttpClient.new(connection_options: {}, http_log: logger)
       )
       client.login(user, password, 'en')
 

--- a/src/vsphere_cpi/spec/integration/nsx_vsphere_spec.rb
+++ b/src/vsphere_cpi/spec/integration/nsx_vsphere_spec.rb
@@ -6,22 +6,9 @@ describe 'NSX for vsphere integration', nsxv: true do
     @nsx_user = fetch_property('BOSH_VSPHERE_CPI_NSX_USER')
     @nsx_password = fetch_property('BOSH_VSPHERE_CPI_NSX_PASSWORD')
     @nsx_ca_cert = ENV['BOSH_VSPHERE_CPI_NSX_CA_CERT']
-    if @nsx_ca_cert
-      @ca_cert_file = Tempfile.new('bosh-cpi-ca-cert')
-      @ca_cert_file.write(@nsx_ca_cert)
-      @ca_cert_file.close
-      ENV['BOSH_NSX_CA_CERT_FILE'] = @ca_cert_file.path
-    end
 
     @nsx_lb_name = fetch_property('BOSH_VSPHERE_CPI_NSX_LB_NAME')
     @nsx_pool_name = fetch_property('BOSH_VSPHERE_CPI_NSX_POOL_NAME')
-  end
-
-  after (:all) do
-    if @nsx_ca_cert
-      ENV.delete('BOSH_NSX_CA_CERT_FILE')
-      @ca_cert_file.unlink
-    end
   end
 
   let(:security_group) { "BOSH-CPI-test-#{SecureRandom.uuid}" }
@@ -56,7 +43,8 @@ describe 'NSX for vsphere integration', nsxv: true do
       nsx: {
         address: @nsx_address,
         user: @nsx_user,
-        password: @nsx_password
+        password: @nsx_password,
+        ca_cert: @nsx_ca_cert
       }
     )
   end

--- a/src/vsphere_cpi/spec/integration/nsxt_spec.rb
+++ b/src/vsphere_cpi/spec/integration/nsxt_spec.rb
@@ -24,8 +24,7 @@ describe 'CPI', nsxt_all: true do
 
     if ENV['BOSH_NSXT_CA_CERT_FILE']
       configuration.ssl_ca_cert = ENV['BOSH_NSXT_CA_CERT_FILE']
-    end
-    if ENV['NSXT_SKIP_SSL_VERIFY']
+    else
       configuration.verify_ssl = false
       configuration.verify_ssl_host = false
     end
@@ -48,8 +47,7 @@ describe 'CPI', nsxt_all: true do
     policy_configuration.client_side_validation = false
     if ENV['BOSH_NSXT_CA_CERT_FILE']
       policy_configuration.ssl_ca_cert = ENV['BOSH_NSXT_CA_CERT_FILE']
-    end
-    if ENV['NSXT_SKIP_SSL_VERIFY']
+    else
       policy_configuration.verify_ssl = false
       policy_configuration.verify_ssl_host = false
     end

--- a/src/vsphere_cpi/spec/integration/nsxt_spec.rb
+++ b/src/vsphere_cpi/spec/integration/nsxt_spec.rb
@@ -73,7 +73,8 @@ describe 'CPI', nsxt_all: true do
     VSphereCloud::Cloud.new(cpi_options(nsxt: {
       host: @nsxt_host,
       auth_certificate: @certificate.to_s,
-      auth_private_key: @private_key.to_s
+      auth_private_key: @private_key.to_s,
+      ca_cert_file: ENV['BOSH_NSXT_CA_CERT_FILE']
     }))
   end
 
@@ -155,6 +156,7 @@ describe 'CPI', nsxt_all: true do
           host: @nsxt_host,
           auth_certificate: @certificate.to_s,
           auth_private_key: @private_key.to_s,
+          ca_cert_file: ENV['BOSH_NSXT_CA_CERT_FILE'],
           default_vif_type: 'PARENT'
         }))
       end
@@ -379,6 +381,7 @@ describe 'CPI', nsxt_all: true do
             host: @nsxt_host,
             username: @nsxt_username,
             password: @nsxt_password,
+            ca_cert_file: ENV['BOSH_NSXT_CA_CERT_FILE'],
             use_policy_api: true,
         }))
       end
@@ -409,6 +412,7 @@ describe 'CPI', nsxt_all: true do
               host: @nsxt_host,
               auth_certificate: @certificate.to_s,
               auth_private_key: @private_key.to_s,
+              ca_cert_file: ENV['BOSH_NSXT_CA_CERT_FILE'],
               use_policy_api: true,
           }))
         end
@@ -760,6 +764,7 @@ describe 'CPI', nsxt_all: true do
         host: @nsxt_host,
         username: @nsxt_username,
         password: @nsxt_password,
+        ca_cert_file: ENV['BOSH_NSXT_CA_CERT_FILE'],
         policy_api_migration_mode: true,
       }))
     end
@@ -862,7 +867,8 @@ describe 'CPI', nsxt_all: true do
         VSphereCloud::Cloud.new(cpi_options(nsxt: {
           host: @nsxt_host,
           auth_certificate: @certificate.to_s,
-          auth_private_key: @private_key.to_s
+          auth_private_key: @private_key.to_s,
+          ca_cert_file: ENV['BOSH_NSXT_CA_CERT_FILE']
         }))
       end
       let(:cpi) { management_cpi } #the cpi variable is used to cleanup created VMs.
@@ -1025,6 +1031,7 @@ describe 'CPI', nsxt_all: true do
           host: @nsxt_host,
           username: @nsxt_username,
           password: @nsxt_password,
+          ca_cert_file: ENV['BOSH_NSXT_CA_CERT_FILE'],
           use_policy_api: true,
         }))
       end
@@ -1443,6 +1450,7 @@ describe 'CPI', nsxt_all: true do
               host: @nsxt_host,
               username: @nsxt_username,
               password: @nsxt_password,
+              ca_cert_file: ENV['BOSH_NSXT_CA_CERT_FILE'],
               use_policy_api: true,
           }))
         end

--- a/src/vsphere_cpi/spec/integration/vsphere_cpi_spec.rb
+++ b/src/vsphere_cpi/spec/integration/vsphere_cpi_spec.rb
@@ -48,7 +48,7 @@ module VSphereCloud
 
       client = VSphereCloud::VCenterClient.new(
           vcenter_api_uri: URI.parse("https://#{host}/sdk/vimService"),
-          http_client: VSphereCloud::CpiHttpClient.new(logger)
+          http_client: VSphereCloud::CpiHttpClient.new(connection_options: {}, http_log: logger)
       )
       client.login(user, password, 'en')
 

--- a/src/vsphere_cpi/spec/spec_helper.rb
+++ b/src/vsphere_cpi/spec/spec_helper.rb
@@ -20,7 +20,7 @@ require 'cloud'
 proc {
   host = ENV["BOSH_VSPHERE_CPI_HOST"]
   logger = Logger.new(STDERR)
-  $vc_version = VmodlVersionDiscriminant.retrieve_vmodl_version(host, logger)
+  $vc_version = VmodlVersionDiscriminant.retrieve_vmodl_version(host, {}, logger)
 }.call if ENV["BOSH_VSPHERE_CPI_HOST"]
 
 # set $vc_version for unit tests

--- a/src/vsphere_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/vsphere_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -86,6 +86,7 @@ describe 'cpi.json.erb' do
               'host' => 'vcenter-address',
               'password' => 'vcenter-password',
               'user' => 'vcenter-user',
+              'connection_options' => { 'ca_cert' => nil },
               'default_disk_type' => 'preallocated',
               'enable_auto_anti_affinity_drs_rules' => true,
               'enable_human_readable_name' => true,

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/base_http_client_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/base_http_client_spec.rb
@@ -238,7 +238,7 @@ module VSphereCloud
     context 'when we have an SSL certificate verification error' do
       context 'and it can be remedied by setting a property' do
         subject(:http_client) { BaseHttpClient.new(trusted_ca_file: certificate(:failure).path, ca_cert_manifest_key: 'vcenter.nsx.ca_cert') }
-        it 'should raise a generic error message without a remedy suggestion' do
+        it 'should raise a generic error message with a remedy suggestion' do
           expect {
             http_client.get("https://localhost:#{@server.port}")
           }.to raise_error(/vcenter.nsx.ca_cert/)

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -874,6 +874,7 @@ module VSphereCloud
             soap_log: 'fake-log-file',
             nsx_user: 'fake-nsx-user',
             nsx_password: 'fake-nsx-password',
+            nsx_ca_cert_file: 'fake-nsx-ca-cert-file',
             nsxt_enabled?: false
           ).as_null_object
         end
@@ -909,7 +910,7 @@ module VSphereCloud
         it 'should create the security tags and attach them to the VM' do
           allow(VmConfig).to receive(:new).and_return(vm_config)
           allow(NsxHttpClient).to receive(:new)
-                            .with('fake-nsx-user', 'fake-nsx-password', 'fake-log-file')
+                            .with('fake-nsx-user', 'fake-nsx-password', 'fake-nsx-ca-cert-file', 'fake-log-file')
                             .and_return(http_basic_auth_client)
           allow(NSX).to receive(:new).and_return(nsx)
 
@@ -970,7 +971,7 @@ module VSphereCloud
           it 'should de-duplicate the security tags and attach them to the VM' do
             allow(VmConfig).to receive(:new).and_return(vm_config)
             allow(NsxHttpClient).to receive(:new)
-              .with('fake-nsx-user', 'fake-nsx-password', 'fake-log-file')
+              .with('fake-nsx-user', 'fake-nsx-password', 'fake-nsx-ca-cert-file', 'fake-log-file')
               .and_return(http_basic_auth_client)
             allow(NSX).to receive(:new).and_return(nsx)
 
@@ -1028,7 +1029,7 @@ module VSphereCloud
           it 'should de-duplicate the security tags and attach them to the VM' do
             allow(VmConfig).to receive(:new).and_return(vm_config)
             allow(NsxHttpClient).to receive(:new)
-              .with('fake-nsx-user', 'fake-nsx-password', 'fake-log-file')
+              .with('fake-nsx-user', 'fake-nsx-password', 'fake-nsx-ca-cert-file', 'fake-log-file')
               .and_return(http_basic_auth_client)
             allow(NSX).to receive(:new).and_return(nsx)
 
@@ -1083,7 +1084,7 @@ module VSphereCloud
           it 'should de-duplicate the security tags and attach them to the VM' do
             allow(VmConfig).to receive(:new).and_return(vm_config)
             allow(NsxHttpClient).to receive(:new)
-              .with('fake-nsx-user', 'fake-nsx-password', 'fake-log-file')
+              .with('fake-nsx-user', 'fake-nsx-password', 'fake-nsx-ca-cert-file', 'fake-log-file')
               .and_return(http_basic_auth_client)
             allow(NSX).to receive(:new).and_return(nsx)
 
@@ -1133,7 +1134,7 @@ module VSphereCloud
           it 'should de-duplicate the security tags and attach them to the VM' do
             allow(VmConfig).to receive(:new).and_return(vm_config)
             allow(NsxHttpClient).to receive(:new)
-              .with('fake-nsx-user', 'fake-nsx-password', 'fake-log-file')
+              .with('fake-nsx-user', 'fake-nsx-password', 'fake-nsx-ca-cert-file', 'fake-log-file')
               .and_return(http_basic_auth_client)
             allow(NSX).to receive(:new).and_return(nsx)
 
@@ -1174,7 +1175,7 @@ module VSphereCloud
           it 'should not call add_vm_to_security_group VM' do
             allow(VmConfig).to receive(:new).and_return(vm_config)
             allow(NsxHttpClient).to receive(:new)
-              .with('fake-nsx-user', 'fake-nsx-password', 'fake-log-file')
+              .with('fake-nsx-user', 'fake-nsx-password', 'fake-nsx-ca-cert-file', 'fake-log-file')
               .and_return(http_basic_auth_client)
             allow(NSX).to receive(:new).and_return(nsx)
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -27,6 +27,7 @@ module VSphereCloud
         vcenter_user: 'fake-user',
         vcenter_password: 'fake-password',
         vcenter_default_disk_type: default_disk_type,
+        vcenter_connection_options: 'fake-connection-options',
         soap_log: 'fake-log-file',
         vcenter_enable_auto_anti_affinity_drs_rules: false,
         upgrade_hw_version: true,
@@ -75,7 +76,7 @@ module VSphereCloud
       allow(Config).to receive(:build).with(config).and_return(cloud_config)
       unless example.metadata[:skip_before]
         allow(CpiHttpClient).to receive(:new)
-          .with('fake-log-file')
+          .with(connection_options: 'fake-connection-options', http_log: 'fake-log-file')
           .and_return(http_client)
         allow(VCenterClient).to receive(:new)
                                   .with(
@@ -258,9 +259,9 @@ module VSphereCloud
         let(:dvs_index) { { 'fake_pgkey1' => 'fake_network1' } }
 
         it 'generates the network env' do
-          
+
           allow(datacenter).to receive_message_chain(:mob, :network, :detect).and_return(nil)
-          allow(cloud_searcher).to receive(:find_resources_by_property_path).and_return([]) 
+          allow(cloud_searcher).to receive(:find_resources_by_property_path).and_return([])
           expect(vsphere_cloud.generate_network_env(devices, networks, dvs_index)).to eq(expected_output)
         end
       end
@@ -283,7 +284,7 @@ module VSphereCloud
 
         it 'generates the network env' do
           allow(datacenter).to receive(:mob)
-          allow(cloud_searcher).to receive(:find_resources_by_property_path).and_return([dvpg]) 
+          allow(cloud_searcher).to receive(:find_resources_by_property_path).and_return([dvpg])
           allow(dvpg).to receive(:config).and_return(dvpg_config)
           expect(vsphere_cloud.generate_network_env(devices, networks, dvs_index)).to eq(expected_output)
         end
@@ -460,7 +461,6 @@ module VSphereCloud
 
       before do
         expect(VCPIExtension).to receive(:create_cpi_extension) # .with(config).and_return(cloud_config)
-        allow(VSphereCloud::CpiHttpClient).to receive(:new).with(no_args)
         allow(vsphere_cloud).to receive(:`).and_return(`true`)
         allow(vsphere_cloud).to receive(:enable_telemetry)
         allow(Dir).to receive(:entries).and_return(["foo.ovf"])
@@ -870,6 +870,7 @@ module VSphereCloud
             vcenter_user: 'fake-user',
             vcenter_password: 'fake-password',
             vcenter_default_disk_type: default_disk_type,
+            vcenter_connection_options: 'fake-connection-options',
             soap_log: 'fake-log-file',
             nsx_user: 'fake-nsx-user',
             nsx_password: 'fake-nsx-password',
@@ -1203,6 +1204,7 @@ module VSphereCloud
             vcenter_user: 'fake-user',
             vcenter_password: 'fake-password',
             vcenter_default_disk_type: default_disk_type,
+            vcenter_connection_options: 'fake-connection-options',
             soap_log: 'fake-log-file',
             nsxt_enabled?: true,
             nsxt: nsxt_config

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -2898,7 +2898,7 @@ module VSphereCloud
     describe '#replace_certs_keys_with_temp_files' do
       let(:nsxt_config) do
         VSphereCloud::NSXTConfig.new(
-          'host', 'user', 'password', 'true', 'cert', 'key', 'BARE_METAL'
+          'host', 'user', 'password', 'ca-cert', 'true', 'cert', 'key', 'BARE_METAL'
         )
       end
       it 'replaces certs and keys with their tempfile locations' do
@@ -2912,7 +2912,7 @@ module VSphereCloud
       context 'when auth key is not provided' do
         let(:nsxt_config) do
           VSphereCloud::NSXTConfig.new(
-              'host', 'user', 'password', 'true', 'cert', nil, 'BARE_METAL'
+              'host', 'user', 'password', 'ca-cert', 'true', 'cert', nil, 'BARE_METAL'
           )
         end
         it 'does not do anything on passed nsxt config' do

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/nsx_http_client_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/nsx_http_client_spec.rb
@@ -15,6 +15,12 @@ module VSphereCloud
     end
 
     describe 'SSL validation' do
+      context 'when no CA cert file is provided' do
+        it 'does not validate the NSX certificate when connecting' do
+          expect(backing_client.ssl_config.verify_mode).to eq(OpenSSL::SSL::VERIFY_NONE)
+        end
+      end
+
       context 'when the CA cert file provided signs the NSX cert' do
         let(:ca_cert_file) { certificate(:success).path }
 
@@ -37,12 +43,6 @@ module VSphereCloud
             http_client.get("https://localhost:#{@server.port}")
           }.to raise_error(/does not have a valid SSL certificate.*vcenter.nsx.ca_cert/)
         end
-      end
-
-      it 'fails when a CA bundle is not provided' do
-        expect {
-          http_client.get("https://localhost:#{@server.port}")
-        }.to raise_error(/vcenter.nsx.ca_cert/)
       end
     end
   end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/nsx_http_client_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/nsx_http_client_spec.rb
@@ -18,7 +18,7 @@ module VSphereCloud
     end
 
     describe 'SSL validation' do
-      it 'configures SSL when BOSH_CA_CERT_FILE has been set in the environment' do
+      it 'configures SSL when BOSH_NSX_CA_CERT_FILE has been set in the environment' do
         cert = certificate(:success)
         ENV["BOSH_NSX_CA_CERT_FILE"] = cert.path
         expect(backing_client.ssl_config.verify_mode).to eq(OpenSSL::SSL::VERIFY_PEER | OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT)


### PR DESCRIPTION
Previously, the CPI wrote the CA certs for vCenter, NSX, and NSX-T to disk as part of BOSH templating. This works correctly for environments with a single CPI config. However, in environments that have 2 or more vSphere CPI configs, the CA certs for the specific config used are passed at runtime by the BOSH Director when invoking the CPI. The CPI was always using the CA certs rendered to disk, meaning the CAs in other CPI configs would be ignored and could cause TLS verification failures during the deploy.

Now, instead of rendering the CA certs to disk during BOSH templating, they are written to disk as temporary files once the updated config for the specific CPI is received and merged (the `context` variable in the lambda in the `vsphere_cpi` executable). Temporary files were chosen rather than re-writing the templated file to avoid problems when multiple CPI invocations occur concurrently.