### PR TITLE
`pci_passthroughs` enables Dynamic DirectPath IO

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/pci_passthrough.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/pci_passthrough.rb
@@ -3,6 +3,17 @@ module VSphereCloud
     class PCIPassthrough
       @@key = 0
 
+      def self.create_pci_passthrough(vendor_id:, device_id:)
+        allowed_device = VimSdk::Vim::Vm::Device::VirtualPCIPassthrough::AllowedDevice.new
+        allowed_device.vendor_id = vendor_id
+        allowed_device.device_id = device_id
+        backing = VimSdk::Vim::Vm::Device::VirtualPCIPassthrough::DynamicBackingInfo.new
+        backing.allowed_device = [allowed_device]
+        virtual_pci_passthrough = VimSdk::Vim::Vm::Device::VirtualPCIPassthrough.new
+        virtual_pci_passthrough.backing = backing
+        virtual_pci_passthrough
+      end
+
       def self.create_vgpu(vgpu)
         backing = VimSdk::Vim::Vm::Device::VirtualPCIPassthrough::VmiopBackingInfo.new.tap do |backing_info|
           backing_info.vgpu = vgpu

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
@@ -72,6 +72,10 @@ module VSphereCloud
       @manifest_params[:agent_env]
     end
 
+    def pci_passthroughs
+      vm_type.pci_passthroughs || []
+    end
+
     def storage_policy_name
       @manifest_params[:storage_policy]
     end

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_type.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_type.rb
@@ -14,10 +14,29 @@ module VSphereCloud
       @pbm = pbm
     end
 
-    %w[cpu ram disk cpu_hot_add_enabled memory_hot_add_enabled nsx vmx_options vgpus
-       nsxt memory_reservation_locked_to_max nested_hardware_virtualization
-       upgrade_hw_version datacenters vm_group disable_drs storage_policy tags].each do |name|
-      define_method(name) { @cloud_properties[name] }
+    CLOUD_PROPERTIES_HASH_PROXY_METHODS = %w[
+      cpu
+      cpu_hot_add_enabled
+      datacenters
+      disable_drs
+      disk
+      memory_hot_add_enabled
+      memory_reservation_locked_to_max
+      nested_hardware_virtualization
+      nsx
+      nsxt
+      pci_passthroughs
+      ram
+      storage_policy
+      tags
+      upgrade_hw_version
+      vgpus
+      vm_group
+      vmx_options
+    ]
+
+    CLOUD_PROPERTIES_HASH_PROXY_METHODS.each do |method_name|
+      define_method(method_name) { @cloud_properties[method_name] }
     end
 
     def storage_list

--- a/src/vsphere_cpi/spec/spec_helper.rb
+++ b/src/vsphere_cpi/spec/spec_helper.rb
@@ -24,7 +24,7 @@ proc {
 }.call if ENV["BOSH_VSPHERE_CPI_HOST"]
 
 # set $vc_version for unit tests
-$vc_version = '6.5' if $vc_version.nil?
+$vc_version = '7.0' if $vc_version.nil?
 
 require 'cloud/vsphere'
 require 'base64'

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/pci_passthrough_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/pci_passthrough_spec.rb
@@ -1,6 +1,16 @@
 require 'spec_helper'
 
 describe VSphereCloud::Resources::PCIPassthrough do
+  describe '#create_pci_passthrough' do
+    let(:device_id) { 'some-device' }
+    let(:vendor_id) { 'some-vendor' }
+    it 'creates a PCI Passthrough device' do
+      spec = described_class.create_pci_passthrough(vendor_id:, device_id:)
+      expect(spec.backing.allowed_device.length).to eq(1)
+      expect(spec.backing.allowed_device.first.device_id).to eq('some-device')
+      expect(spec.backing.allowed_device.first.vendor_id).to eq('some-vendor')
+    end
+  end
   describe '#create_vgpu' do
     let(:vgpu) { 'fake-vgpu-name' }
     it 'creates a vgpu' do

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_config_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_config_spec.rb
@@ -304,6 +304,18 @@ module VSphereCloud
       end
     end
 
+    describe '#pci_passthroughs' do
+      let(:cloud_properties) { { 'pci_passthroughs' => [
+        { 'vendor_id' => '0x10de',
+          'device_id' => '0x1eb8',
+        }
+      ] } }
+      let(:input) { { vm_type: vm_type } }
+      it 'returns the provided PCI passthroughs' do
+        expect(vm_config.pci_passthroughs).to eq([{'device_id'=>'0x1eb8', 'vendor_id'=>'0x10de'}])
+      end
+    end
+
     describe '#cluster_placements' do
       let(:datastore_mob) { instance_double('VimSdk::Vim::Datastore') }
       let(:cluster_provider) { instance_double(VSphereCloud::Resources::ClusterProvider) }


### PR DESCRIPTION
`pci_passthroughs` enables Dynamic DirectPath IO

We'd like the ability for BOSH-deployed VMs on vSphere to be able to access hardware such as Nvidia graphics cards in order to enable AI-related applications such as machine learning and large language models (LLMs).

This feature requires vSphere 7.0 (Dynamic DirectPath IO requirement).

When `pci_passthroughs` are configured, the properties, `memory_reservation_locked_to_max` and `upgrade_hw_version` are additionally to `true`. The former is a requirement for PCI Passthrough, the latter, for Dynamic PCI Passthrough. Jammy stemcells have a too-low [hardware version](https://kb.vmware.com/s/article/1003746) (13); Dynamic PCI Passthrough requires 17+.

We chose [Dynamic DirectPath IO](https://kb.vmware.com/s/article/2142307) (DDPIO) instead of the earlier DirectPath IO because, as far as we can tell, it's more flexible: DDPIO merely requires the PCI card's vendor and device IDs, but the non-Dynamic requires the PCI path on the ESXi host (e.g. `0000:17:00.0`), which can constrain the VM placement to a single host.

Sample VM extension for Nvidia T4 card:

```yaml
vm_extensions:
- cloud_properties:
    pci_passthroughs:
    - vendor_id: 0x10de # Nvidia
      device_id: 0x1eb8 # Tesla T4
  name: gpu
```

We bump the vSphere SDK 6.5 → 7.0 when running unit tests to accommodate the `pci_passthrough_spec.rb`, which otherwise would return the error, "NameError: uninitialized constant Vim.Vm.Device.VirtualPCIPassthrough::AllowedDevice" because `AllowedDevice` only exists in the vSphere 7.0 SDK (it's a component of vSphere's Dynamic DirectPath IO). Note that we have already passed the end of general support (EOGS) for vSphere 6.5 and 6.7 ([2022-10-15](https://core.vmware.com/blog/reminder-vsphere-6567-end-general-support)), and are rapidly approaching end of technical guidance (EOTG) (2023-11-15).

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Related PR and Issues
Fixes # (issue)

## Impacted Areas in Application
List general components of the application that this PR will affect:

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update. See <https://github.com/cloudfoundry/docs-bosh/pull/803> for related documentation change.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

We deployed a VM with an LLM (large language model) to a cluster with two ESXi hosts with an Nvidia Tesla T4 card apiece. We were able to deploy VMs and attach the Nvidia PCI cards and use them.

**Test Configuration**:
* Environment Variables for Integration test: N/A
* Hardware Requirements in ESXi: PCI cards that have passthrough enabled. Also, ESXi must be version 7+.
* Toolchain:
* SDK: 7.0+

# Checklist:

- [x] My code follows the standard ruby style guide
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
