### PR TITLE
Correctly supports gzip-compressed HTTP responses

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/base_http_client.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/base_http_client.rb
@@ -13,6 +13,7 @@ module VSphereCloud
       @backing_client.receive_timeout = 14400
       @backing_client.connect_timeout = 60
       @backing_client.tcp_keepalive = true
+      @backing_client.transparent_gzip_decompression = true #The 'httpclient' gem doesn't handle gzip-compressed responses by default.
       @ca_cert_manifest_key = ca_cert_manifest_key
       @log_filter = VSphereCloud::SdkHelpers::LogFilter.new
 

--- a/src/vsphere_cpi/lib/ruby_vim_sdk/soap/stub_adapter.rb
+++ b/src/vsphere_cpi/lib/ruby_vim_sdk/soap/stub_adapter.rb
@@ -18,7 +18,6 @@ module VimSdk
       def invoke_method(managed_object, method_info, arguments, outer_stub = nil)
         outer_stub = self if outer_stub.nil?
         headers = {'SOAPAction' => @version_id,
-                   'Accept-Encoding' => 'gzip, deflate',
                    'Content-Type' => "text/xml; charset=#{XML_ENCODING}"}
 
         request = serialize_request(managed_object, method_info, arguments)


### PR DESCRIPTION
**NOTE**: I have only run the unit tests on this change. (The unit tests all succeed.) I have not run any integration tests, so they may fail.

**NOTE 2**: We should PROBABLY say something the release notes like "Versions of the CPI older than whatever version contains this fix are NOT COMPATIBLE with vCenters earlier than 8.0.2".


# Description

This commit correctly supports HTTP communication with the yet-to-be-released vSphere 8.0.3. It does this by correctly configuring the 'httpclient' gem to request and handle gzip-compressed HTTP responses.

The 'httpclient' gem does NOT handle gzip-compressed HTTP responses without additional configuration, so doing what the previous incarnation of this code did and manually adding 'Accept-Encoding: gzip, deflate' to the request headers causes the gem to pass gzip-compressed data to the calling code, rather than the uncompressed response body.

Versions of vSphere prior to 8.0.3 ignored the "Accept-Encoding: gzip" header and always returned uncompressed responses. Version 8.0.3 now honors that header, which causes the CPI to immediately fail to communicate with the vCenter.

The stacktrace from such a failure looks like this:

```
 undefined method `property_collector' for nil:NilClass

          @property_collector = service_instance.retrieve_content.property_collector
                                                                 ^^^^^^^^^^^^^^^^^^^. backtrace:
vsphere_cpi/lib/ruby_vim_sdk/soap/stub_adapter.rb:57:in `invoke_property'
vsphere_cpi/lib/cloud/vsphere/sdk_helpers/retryable_stub_adapter.rb:85:in `invoke_property'
vsphere_cpi/lib/ruby_vim_sdk/vmodl/managed_object.rb:17:in `invoke_property'
vsphere_cpi/lib/ruby_vim_sdk/vmodl/managed_object.rb:30:in `block (3 levels) in finalize'
vsphere_cpi/lib/cloud/vsphere/vcenter_client.rb:27:in `initialize'
vsphere_cpi/lib/cloud/vsphere/cloud.rb:81:in `new'
vsphere_cpi/lib/cloud/vsphere/cloud.rb:81:in `initialize'
vsphere_cpi/lib/cloud/vsphere.rb:97:in `new'
vsphere_cpi/lib/cloud/vsphere.rb:97:in `initialize'
vsphere_cpi/bin/vsphere_cpi:62:in `new'
vsphere_cpi/bin/vsphere_cpi:62:in `block in <top (required)>'
vsphere_cpi/vendor/bundle/ruby/3.1.0/gems/bosh_cpi-2.5.0/lib/bosh/cpi/cli.rb:87:in `run'
<extraneous stack frames trimmed>
```

Enabling HTTP request tracing (by -say- setting
`cloud_provider.properties.http_logging=true` in the Bosh Director Manifest) causes the system to report that responses you expect to be plaintext are binary data:

```
POST https://vcenter.lan/sdk/vimService
Date: 2023-09-27 21:41:25 +0000
Additional Request Headers:
SOAPAction: "urn:vim25/8.0.0.0"
Accept-Encoding: gzip, deflate
Content-Type: text/xml; charset=UTF-8
Request Body:
<?xml version="1.0" encoding="UTF-8"?>
<soapenv:Envelope xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
<soapenv:Body><RetrieveServiceContent xmlns="urn:vim25"><_this type="ServiceInstance">ServiceInstance</_this></RetrieveServiceContent></soapenv:Body>
</soapenv:Envelope>
= Response
Status: 200 OK
Response Headers:
cache-control: no-cache
content-type: text/xml; charset=utf-8
date: Wed, 27 Sep 2023 21:42:34 GMT
x-envoy-upstream-service-time: 2
vary: Accept-Encoding
content-encoding: gzip
transfer-encoding: chunked
Response Body:
RESPONSE BODY IS BINARY DATA
````

## Impacted Areas in Application
vSphere <-> CPI communication... which is basically almost the entire purpose of the CPI.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [X] Manual testing against a live vSphere 8.0.3 by replacing the CPI bundled with an Ops Manager configured to use an 8.0.3 vSphere.
- [X] Run all the unit tests
- [ ] Integration tests HAVE NOT been run.

# Checklist:

- [ ] My code follows the standard ruby style guide
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
