### PR TITLE
🐞 `pci_passthroughs` reserve memory

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
@@ -238,6 +238,9 @@ module VSphereCloud
       if vgpus.size > 0
         return true
       end
+      if pci_passthroughs.size > 0
+        return true
+      end
       false
     end
   end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_config_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_config_spec.rb
@@ -596,7 +596,7 @@ module VSphereCloud
           expect(vm_config.config_spec_params).to eq(output)
         end
 
-        context 'but the VM has vgpus' do
+        context 'the VM has vgpus' do
           let(:cloud_properties) do
             {
               'memory_reservation_locked_to_max' => false,
@@ -609,6 +609,21 @@ module VSphereCloud
             expect(vm_config.config_spec_params).to eq(output)
           end
         end
+
+        context 'the VM has pci_passthroughs' do
+          let(:cloud_properties) do
+            {
+              'memory_reservation_locked_to_max' => false,
+              'pci_passthroughs' => [{'vendor_id' => 0x1, 'device_id' => 0x2}],
+            }
+          end
+          let(:output) { { memory_reservation_locked_to_max: true } }
+
+          it 'overrides memory_reservation_locked_to_max, setting it to true' do
+            expect(vm_config.config_spec_params).to eq(output)
+          end
+        end
+
       end
 
       context 'when memory_reservation_locked_to_max is true' do


### PR DESCRIPTION
# Description

When `pci_passthroughs` are configured, `memory_reservation_locked_to_max` should also be set, but wasn't, causing deploys to fail.

With this commit, `memory_reservation_locked_to_max` is now set when `pci_passthroughs` are configured.

Fixes, during `bosh deploy`:
```
Error: Unknown CPI error 'Unknown' with message 'Invalid memory setting: memory reservation (sched.mem.min) should be equal to memsize(32768). ' in 'create_vm' CPI method
```

**[Bug Fix]** vSphere reserves memory when `pci_passthroughs` are configured, allowing deployments to succeed.

## Related PR and Issues

N/A

## Impacted Areas in Application

This affects customers who are deploying with GPUs (`pci_passthroughs`).

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] hot-patched a live Director to make sure the deploy succeeded with code change
- [X] wrote unit tests

**Test Configuration**:
* Environment Variables for Integration test: N/A
* Hardware Requirements in ESXi: hardware that's available to be passed through to the VM
* Toolchain: ?
* SDK: 7.0+

# Checklist:

- [X] My code follows the standard ruby style guide
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
