### PR TITLE
Remove alarmist errors from CPI log

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/sdk_helpers/retryable_stub_adapter.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/sdk_helpers/retryable_stub_adapter.rb
@@ -68,6 +68,10 @@ module VSphereCloud
             end
 
             if err
+              # Don't trouble the user with "Error running method 'AddCustomFieldDef'. Failed with message 'The name 'created_at' already exists.'."
+              if method_name == 'AddCustomFieldDef' && object.kind_of?(VimSdk::Vim::Fault::DuplicateName)
+                  break
+              end
               unless SILENT_ERROR_METHOD.include?(method_name)
                 logger.warn(fault_message(method_name, err))
               end
@@ -97,7 +101,7 @@ module VSphereCloud
 
       def fault_message(method_name, err)
         msg = "Error running method '#{method_name}'. Failed with message '#{err.message}'"
-        if err.fault && err.fault.fault_cause
+        if err.fault&.fault_cause
           msg += " and cause '#{err.fault.fault_cause}'"
         end
         msg << '.'


### PR DESCRIPTION
Every time [0] we `create_vm`, we generate nine alarmist error messages, which on at least two occasions have concerned users. The errors are innocuous. Ironically, their absence would indicate something is wrong.

This commit redacts those alarmist messages.

For context, the "Custom Field Definitions" can be viewed on the vCenter Web UI as "Custom Attributes", and they are vCenter-wide (in other words, even VMs not deployed by BOSH will have at least nine custom attributes such as "cpi_metadata_version").

Fixes, when running `bosh task xxx --cpi`:

```
Error running method 'AddCustomFieldDef'. Failed with message 'The name 'cpi_metadata_version' already exists.'.
Error running method 'AddCustomFieldDef'. Failed with message 'The name 'director' already exists.'.
Error running method 'AddCustomFieldDef'. Failed with message 'The name 'deployment' already exists.'.
Error running method 'AddCustomFieldDef'. Failed with message 'The name 'id' already exists.'.
Error running method 'AddCustomFieldDef'. Failed with message 'The name 'job' already exists.'.
Error running method 'AddCustomFieldDef'. Failed with message 'The name 'instance_group' already exists.'.
Error running method 'AddCustomFieldDef'. Failed with message 'The name 'index' already exists.'.
Error running method 'AddCustomFieldDef'. Failed with message 'The name 'name' already exists.'.
Error running method 'AddCustomFieldDef'. Failed with message 'The name 'created_at' already exists.'.
```

[0] The only time we would not see these error messages would be the very first time BOSH deploys a VM to a given vCenter.

Tested on a hot-patched BOSH Director.
