### PR TITLE
Enable expanding root disk size with new property `root_disk_size_gb`

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
@@ -76,6 +76,10 @@ module VSphereCloud
       vm_type.pci_passthroughs || []
     end
 
+    def root_disk_size_gb
+      vm_type.root_disk_size_gb.to_i
+    end
+
     def storage_policy_name
       @manifest_params[:storage_policy]
     end

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_type.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_type.rb
@@ -27,6 +27,7 @@ module VSphereCloud
       nsxt
       pci_passthroughs
       ram
+      root_disk_size_gb
       storage_policy
       tags
       upgrade_hw_version

--- a/src/vsphere_cpi/spec/integration/root_size_disk_gb_spec.rb
+++ b/src/vsphere_cpi/spec/integration/root_size_disk_gb_spec.rb
@@ -1,0 +1,37 @@
+require 'integration/spec_helper'
+
+describe 'root_disk_size_gb property' do
+
+  let(:vm_type) do
+    {
+      'ram' => 512,
+      'disk' => 2048,
+      'cpu' => 1,
+    }
+  end
+
+  context 'when "root_disk_size_gb" is not set' do
+    it 'creates a VM whose system disk is a linked-clone to the stemcell' do
+      simple_vm_lifecycle(@cpi, @vlan, vm_type) do |vm_id|
+        vm = @cpi.vm_provider.find(vm_id)
+        stemcell = @cpi.vm_provider.find(@stemcell_id)
+        system_disk = vm.system_disk
+        stemcell_disk = stemcell.system_disk
+        expect(system_disk.backing.parent.uuid).to eq(stemcell_disk.backing.parent.uuid)
+      end
+    end
+  end
+
+  context 'when "root_disk_size_gb" is set' do
+    let(:root_disk_size_gb) { 15 }
+    it 'creates a VM whose system disk is a linked-clone to the stemcell' do
+      vm_type['root_disk_size_gb'] = root_disk_size_gb
+      simple_vm_lifecycle(@cpi, @vlan, vm_type) do |vm_id|
+        vm = @cpi.vm_provider.find(vm_id)
+        system_disk = vm.system_disk
+        expect(system_disk.backing.parent).to be_nil # no parent disk, not a linked-clone
+        expect(system_disk.capacity_in_kb / 1024 / 1024).to eq(root_disk_size_gb) # convert kiB → GiB
+      end
+    end
+  end
+end


### PR DESCRIPTION
Applications such as Nvidia's libraries, required for many AI / LLM applications, aren't easily installed on anywhere but the root disk; however, the amount of free space in the root disk of a Jammy stemcell is too small to accommodate these libraries.

To address this, we introduce a new property, `root_disk_size_gb`. Setting this property will expand the root disk during VM creation (in the `create_vm` CPI method, before the BOSH packages are installed).

Typical use (in a Cloud Config):

```yaml
vm_extensions:
- name: 20G_root
  cloud_properties:
    root_disk_size_gb: 20
```

Setting this property disables the VM's "linked clone" feature [0], which is incompatible with extending the size of the root disk. The VM will therefore require more disk space than expected, typically the size of the root disk (in the above example, 20 GiB)

Adding this feature brings the vSphere CPI to parity with the AWS, Azure, and GCP CPIs.

Root disk size is measured in GiB (1,073,741,824 bytes), not in GB (1,000,000,000 bytes).

Drive-by:

Removed unnecessary initialization, `config_spec.device_change = []`: `ConfigSpec` class initializes `device_change` to an empty array; we don't need to do it.

[0] A linked clone is a copy of a virtual machine that shares virtual disks with the parent virtual machine. Only changes from the parent disk are recorded, saving on disk space.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Related PR and Issues
Fixes # (issue)

## Impacted Areas in Application
List general components of the application that this PR will affect:

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Includes an integration test which was run on vSphere 7.0

# Checklist:

- [X] My code follows the standard ruby style guide
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
