### PR TITLE
Refine documentation for enable_auto_anti_affinity_drs_rules property

### DIFF
--- a/jobs/vsphere_cpi/spec
+++ b/jobs/vsphere_cpi/spec
@@ -24,7 +24,7 @@ properties:
   vcenter.datacenters:
     description: Datacenters in vCenter to use (value is an array of Hashes representing datacenters and clusters, See director.yml.erb.erb)
   vcenter.enable_auto_anti_affinity_drs_rules:
-    description: Creates DRS rule to place VMs on separate hosts.
+    description: Creates anti-affinity DRS rules for each instance group of each bosh deployment to place VMs on separate hosts. The DRS rules are named from template: <bosh-director-name>-<bosh-deployment-name>-<instance-group-name>
     default: false
   vcenter.memory_reservation_locked_to_max:
     description: When enabled, the requested memory for the VMs will be reserved in vCenter. Enabling this will likely lead to wasted memory on the hosts and will prevent vCenter from making the best use of the memory resources.


### PR DESCRIPTION
# Description

Refine existing documentation in spec files for current `enable_auto_anti_affinity_drs_rules` property

Extracted from https://www.pivotaltracker.com/n/projects/1133984/stories/133642741
 >  We can create a DRS rule based on env.bosh.group (skip if this field is not provided).


## Related PR and Issues
See additional analysis of source code detailing this doc update in https://github.com/cloudfoundry/bosh-vsphere-cpi-release/issues/378

## Impacted Areas in Application
List general components of the application that this PR will affect:

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change only performs a documentation update

# Checklist:

- [ ] My code follows the standard ruby style guide
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
