### PR TITLE
Fix lifecycle-8.pre-release-nsxt41-cvds CI job.

### DIFF
--- a/ci/tasks/run-lifecycle.sh
+++ b/ci/tasks/run-lifecycle.sh
@@ -37,7 +37,7 @@ if [ "$BOSH_VSPHERE_CPI_NSXT_HOST" != "null" ]; then
   openssl s_client -showcerts -connect "${BOSH_VSPHERE_CPI_NSXT_HOST}":443 </dev/null 2>/dev/null | openssl x509 -outform PEM > $BOSH_NSXT_CA_CERT_FILE
   # The certificate's SAN contains the host name, so extract it because SSL validation fails when using the IP address
   # NOTE: Don't hard code the name as it is not guaranteed to be "nsxt-manager"
-  BOSH_NSXT_CERT_HOST_NAME="$(openssl x509 -noout -text -in nsxt-manager-cert.pem | awk '/X509v3 Subject Alternative Name/ {getline;gsub(/ /, "", $0); print}' | tr -d "DNS:")"
+  BOSH_NSXT_CERT_HOST_NAME="$(openssl x509 -noout -text -in nsxt-manager-cert.pem | awk '/X509v3 Subject Alternative Name/ {getline;gsub(/ /, "", $0); print}' | tr -d "DNS:" | sed 's/^\*.//')"
   echo "${BOSH_VSPHERE_CPI_NSXT_HOST} ${BOSH_NSXT_CERT_HOST_NAME}" >> /etc/hosts
   export BOSH_VSPHERE_CPI_NSXT_HOST="https://${BOSH_NSXT_CERT_HOST_NAME}"
 fi

--- a/ci/tasks/run-lifecycle.sh
+++ b/ci/tasks/run-lifecycle.sh
@@ -37,7 +37,7 @@ if [ "$BOSH_VSPHERE_CPI_NSXT_HOST" != "null" ]; then
   openssl s_client -showcerts -connect "${BOSH_VSPHERE_CPI_NSXT_HOST}":443 </dev/null 2>/dev/null | openssl x509 -outform PEM > $BOSH_NSXT_CA_CERT_FILE
   # The certificate's SAN contains the host name, so extract it because SSL validation fails when using the IP address
   # NOTE: Don't hard code the name as it is not guaranteed to be "nsxt-manager"
-  BOSH_NSXT_CERT_HOST_NAME="$(openssl x509 -noout -text -in nsxt-manager-cert.pem | awk '/X509v3 Subject Alternative Name/ {getline;gsub(/ /, "", $0); print}' | tr -d "DNS:" | sed 's/^\*./nsx-mgr\./')"
+  BOSH_NSXT_CERT_HOST_NAME="$(openssl x509 -noout -text -in nsxt-manager-cert.pem | awk '/X509v3 Subject Alternative Name/ {getline;gsub(/ /, "", $0); print}' | tr -d "DNS:" | sed 's/^\*\./nsx-mgr./')"
   echo "${BOSH_VSPHERE_CPI_NSXT_HOST} ${BOSH_NSXT_CERT_HOST_NAME}" >> /etc/hosts
   export BOSH_VSPHERE_CPI_NSXT_HOST="https://${BOSH_NSXT_CERT_HOST_NAME}"
 fi

--- a/ci/tasks/run-lifecycle.sh
+++ b/ci/tasks/run-lifecycle.sh
@@ -37,7 +37,7 @@ if [ "$BOSH_VSPHERE_CPI_NSXT_HOST" != "null" ]; then
   openssl s_client -showcerts -connect "${BOSH_VSPHERE_CPI_NSXT_HOST}":443 </dev/null 2>/dev/null | openssl x509 -outform PEM > $BOSH_NSXT_CA_CERT_FILE
   # The certificate's SAN contains the host name, so extract it because SSL validation fails when using the IP address
   # NOTE: Don't hard code the name as it is not guaranteed to be "nsxt-manager"
-  BOSH_NSXT_CERT_HOST_NAME="$(openssl x509 -noout -text -in nsxt-manager-cert.pem | awk '/X509v3 Subject Alternative Name/ {getline;gsub(/ /, "", $0); print}' | tr -d "DNS:" | sed 's/^\*.//')"
+  BOSH_NSXT_CERT_HOST_NAME="$(openssl x509 -noout -text -in nsxt-manager-cert.pem | awk '/X509v3 Subject Alternative Name/ {getline;gsub(/ /, "", $0); print}' | tr -d "DNS:" | sed 's/^\*./nsx-mgr\./')"
   echo "${BOSH_VSPHERE_CPI_NSXT_HOST} ${BOSH_NSXT_CERT_HOST_NAME}" >> /etc/hosts
   export BOSH_VSPHERE_CPI_NSXT_HOST="https://${BOSH_NSXT_CERT_HOST_NAME}"
 fi


### PR DESCRIPTION
# Description

The lifecycle-8.pre-release-nsxt41-cvds job started failing on April 11th due to a change in the platform that it is connecting to.  Specifically, the certificate associated with the NSXT Manager changed it's TLS certificate to use a wild card cert and the hard coded NSXT Manager host name will no long work (fails with SSL errors when trying to connect to the NSX Manager APIs.

This change dynamically creates an NSXT Manager host name based on information in the SAN of the TLS server certificate.  It is aware of SANs that use specific host names or wildcard domain names.  In the case of a wildcard, a new FQDN is derived from the wild card cert's domain name.  This hostname added to the /etc/hosts file and used as the NSX Manager hostname throughout the tests.

## Related PR and Issues
NA

## Impacted Areas in Application
CI only.

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Tested in a temporary CI Pipeline that had accessed to all necessary infrastructure (Nimbus pools) that pointed to a forked repo for the CI task updates (the same forked repo that is part of this PR).  Successfully ran the lifecycle-8.pre-release-nsxt41-cvds job from that temporary pipeline.

To reproduce, updated the pipeline.yaml to point the `source-ci` Git resource to the repo referenced in this PR and install the pipeline on a Concourse instance that has access to the Nimbus pools (can currently only runs on VMware hosted pipelines).  Run the lifecycle-8.pre-release-nsxt41-cvd job and validate that all tests pass.
