### PR TITLE
NSX: tags VMs as well as ports

### DIFF
--- a/jobs/vsphere_cpi/spec
+++ b/jobs/vsphere_cpi/spec
@@ -88,6 +88,9 @@ properties:
   vcenter.nsxt.allow_overwrite:
      description: "When enabled, the CPI sets the X-Allow-Overwrite header to 'true' when making NSX-T API requests. This value currently defaults to true for backwards compatibility."
      default: true
+  vcenter.nsxt.tag_nsx_vm_objects:
+     description: "When enabled, tag NSX VM objects with the same set of tags as vsphere VM objects"
+     default: false
   vcenter.http_logging:
     description: Enables HTTP level logging. Each HTTP request to vcenter will be logged
     default: false

--- a/jobs/vsphere_cpi/templates/cpi.json.erb
+++ b/jobs/vsphere_cpi/templates/cpi.json.erb
@@ -135,6 +135,10 @@
     if_p('vcenter.nsxt.policy_api_migration_mode') do
       vcenter['nsxt']['policy_api_migration_mode'] = p('vcenter.nsxt.policy_api_migration_mode')
     end
+
+    if_p('vcenter.nsxt.tag_nsx_vm_objects') do
+      vcenter['nsxt']['tag_nsx_vm_objects'] = p('vcenter.nsxt.tag_nsx_vm_objects')
+    end
   end
 
   if_p('agent.mbus') do |mbus|

--- a/src/vsphere_cpi/Rakefile
+++ b/src/vsphere_cpi/Rakefile
@@ -13,6 +13,7 @@ namespace :swagger do
       '\'.paths |= {
         "/fabric/vifs",
         "/fabric/virtual-machines",
+        "/fabric/virtual-machines?action=update_tags",
         "/loadbalancer/pools",
         "/loadbalancer/pools/{pool-id}",
         "/logical-ports",

--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -620,6 +620,10 @@ module VSphereCloud
           else
             @nsxt_provider.update_vm_metadata_on_logical_ports(vm, metadata)
           end
+
+          if @config.nsxt.tag_nsx_vm_objects?
+            @nsxt_provider.update_vm_metadata_on_vm_objects(vm, metadata)
+          end
        end
       end
     end

--- a/src/vsphere_cpi/lib/cloud/vsphere/config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/config.rb
@@ -1,5 +1,5 @@
 module VSphereCloud
-  class NSXTConfig < Struct.new(:host, :username, :password, :ca_cert_file, :remote_auth, :auth_certificate, :auth_private_key, :default_vif_type, :use_policy_api, :policy_api_migration_mode, :allow_overwrite)
+  class NSXTConfig < Struct.new(:host, :username, :password, :ca_cert_file, :remote_auth, :auth_certificate, :auth_private_key, :default_vif_type, :use_policy_api, :policy_api_migration_mode, :allow_overwrite, :tag_nsx_vm_objects)
     def self.validate_schema(config)
       return true if config.nil?
 
@@ -33,6 +33,10 @@ module VSphereCloud
     def allow_overwrite?
       return true if allow_overwrite.nil?
       allow_overwrite
+    end
+
+    def tag_nsx_vm_objects?
+      !!tag_nsx_vm_objects
     end
   end
 
@@ -244,6 +248,7 @@ module VSphereCloud
         vcenter['nsxt']['use_policy_api'],
         vcenter['nsxt']['policy_api_migration_mode'],
         vcenter['nsxt']['allow_overwrite'],
+        vcenter['nsxt']['tag_nsx_vm_objects'],
       )
     end
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/nsxt_provider.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/nsxt_provider.rb
@@ -228,18 +228,15 @@ module VSphereCloud
       return if nsxt_nics(vm).empty?
       tags = vm_fabric_svc.list_virtual_machines(display_name: vm.cid).results.first.tags || []
 
-      # update_virtual_machine_tags_update_tags_with_http_info
       metadata.each do |metadata_key, metadata_value|
-        metadata_key = "bosh/" + metadata_key
+        metadata_key = "bosh/#{metadata_key}"
         if metadata_key == "bosh/id"
           metadata_value = Digest::SHA1.hexdigest(metadata_value)
         end
-        bosh_tag = NSXT::Tag.new('scope' => metadata_key, 'tag' => metadata_value)
-        # bosh_tag = {'scope' => metadata_key, 'tag' => metadata_value}
-        # tags.delete_if { |tag| tag.scope == metadata_key }
-        tags << bosh_tag
+        tags << NSXT::Tag.new('scope' => metadata_key, 'tag' => metadata_value)
       end
       external_id = vm_fabric_svc.list_virtual_machines(display_name: vm.cid).results.first.external_id
+
       vm_fabric_svc.update_virtual_machine_tags_update_tags_with_http_info({"external_id" => external_id, "tags" => tags.map(&:to_hash)})
     end
 

--- a/src/vsphere_cpi/lib/nsxt_manager_client/nsxt_manager_client/api/management_plane_api_fabric_virtual_machines_api.rb
+++ b/src/vsphere_cpi/lib/nsxt_manager_client/nsxt_manager_client/api/management_plane_api_fabric_virtual_machines_api.rb
@@ -99,5 +99,58 @@ module NSXT
       end
       return data, status_code, headers
     end
+    # Update tags applied to a virtual machine
+    # Update tags applied to the virtual machine. External id of the virtual machine will be specified in the request body. Request body should contain all the tags to be applied. To clear all tags, provide an empty list. User can apply maximum 25 tags on a virtual machine. The remaining 5 are reserved for system defined tags.
+    # @param virtual_machine_tag_update 
+    # @param [Hash] opts the optional parameters
+    # @return [nil]
+    def update_virtual_machine_tags_update_tags(virtual_machine_tag_update, opts = {})
+      update_virtual_machine_tags_update_tags_with_http_info(virtual_machine_tag_update, opts)
+      nil
+    end
+
+    # Update tags applied to a virtual machine
+    # Update tags applied to the virtual machine. External id of the virtual machine will be specified in the request body. Request body should contain all the tags to be applied. To clear all tags, provide an empty list. User can apply maximum 25 tags on a virtual machine. The remaining 5 are reserved for system defined tags.
+    # @param virtual_machine_tag_update 
+    # @param [Hash] opts the optional parameters
+    # @return [Array<(nil, Fixnum, Hash)>] nil, response status code and response headers
+    def update_virtual_machine_tags_update_tags_with_http_info(virtual_machine_tag_update, opts = {})
+      if @api_client.config.debugging
+        @api_client.config.logger.debug 'Calling API: ManagementPlaneApiFabricVirtualMachinesApi.update_virtual_machine_tags_update_tags ...'
+      end
+      # verify the required parameter 'virtual_machine_tag_update' is set
+      if @api_client.config.client_side_validation && virtual_machine_tag_update.nil?
+        fail ArgumentError, "Missing the required parameter 'virtual_machine_tag_update' when calling ManagementPlaneApiFabricVirtualMachinesApi.update_virtual_machine_tags_update_tags"
+      end
+      # resource path
+      local_var_path = '/fabric/virtual-machines?action=update_tags'
+
+      # query parameters
+      query_params = {}
+
+      # header parameters
+      header_params = {}
+      # HTTP header 'Accept' (if needed)
+      header_params['Accept'] = @api_client.select_header_accept(['application/json'])
+      # HTTP header 'Content-Type'
+      header_params['Content-Type'] = @api_client.select_header_content_type(['application/json'])
+
+      # form parameters
+      form_params = {}
+
+      # http body (model)
+      post_body = @api_client.object_to_http_body(virtual_machine_tag_update)
+      auth_names = ['BasicAuth']
+      data, status_code, headers = @api_client.call_api(:POST, local_var_path,
+        :header_params => header_params,
+        :query_params => query_params,
+        :form_params => form_params,
+        :body => post_body,
+        :auth_names => auth_names)
+      if @api_client.config.debugging
+        @api_client.config.logger.debug "API called: ManagementPlaneApiFabricVirtualMachinesApi#update_virtual_machine_tags_update_tags\nData: #{data.inspect}\nStatus code: #{status_code}\nHeaders: #{headers}"
+      end
+      return data, status_code, headers
+    end
   end
 end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/config_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/config_spec.rb
@@ -350,6 +350,56 @@ module VSphereCloud
       end
     end
 
+      context '#nsxt.tag_nsx_vm_objects' do
+        context 'when not set' do
+          before do
+            config_hash['vcenters'].first.merge! 'nsxt' => {
+              'host' => 'fake-host',
+              'username' => 'fake-username',
+              'password' => 'fake-password',
+              'certificate' => nil,
+              'private_key' => nil,
+            }
+          end
+
+          it 'returns false by default' do
+            expect(config.nsxt.tag_nsx_vm_objects?).to be(false)
+          end
+        end
+        context 'when it is set to true' do
+          before do
+            config_hash['vcenters'].first.merge! 'nsxt' => {
+              'host' => 'fake-host',
+              'username' => 'fake-username',
+              'password' => 'fake-password',
+              'certificate' => nil,
+              'private_key' => nil,
+              'tag_nsx_vm_objects' => true
+            }
+          end
+
+          it 'returns true' do
+            expect(config.nsxt.tag_nsx_vm_objects?).to be(true)
+          end
+        end
+
+        context 'when it is set to false' do
+          before do
+            config_hash['vcenters'].first.merge! 'nsxt' => {
+              'host' => 'fake-host',
+              'username' => 'fake-username',
+              'password' => 'fake-password',
+              'certificate' => nil,
+              'private_key' => nil,
+              'tag_nsx_vm_objects' => false
+            }
+          end
+
+          it 'returns false' do
+            expect(config.nsxt.tag_nsx_vm_objects?).to be(false)
+          end
+        end
+      end
       context 'when a valid nsxt with remote auth is passed in config' do
         before do
           config_hash.merge! 'nsxt' => {


### PR DESCRIPTION
# Description

This commit updates the 'set_vm_metadata' operation to tag NSX VM objects with the same set of tags that are being set on vSphere VM objects. This commit also adds a configuration option to enable to disable this new tagging: 'vcenter.nsxt.tag_nsx_vm_objects'. This new tagging is disabled by default. Also added is the generated code required to access the endpoint used in this new feature.

Why:

For large users with automation, NSX segment port tagging is not enough: Specifically, when setting membership criteria of Groups, the tag matching operators are too limited:

- Tag: Equals, Not Equals, Not In
- Scope: Equals, Not Equals

This prevents writing generic rules such as, "if the Scope is 'bosh/deployment' and the Tag begins with 'cf-' and the Scope is 'bosh/instance_group' and the Tag is 'router', then place it in the Web group"

But tagging the VMs offers a richer set of criteria:

- Tag: Equals, Contains, Starts With, Ends With
- Scope: Equals

This is relevant for one particular user that wants to match against the beginning of our 'bosh/deployment' tags. They cannot do an 'Equals' match because the deployment name has an unpredictable final component. This requires a 'Starts With' matcher to be useful.

Gotchas:

It appears that the endpoint we're using to tag the VMs only exists in the Manager API, not in the Policy API. Because there is no equivalent of this endpoint in the Policy API, we're fairly confident that this is one of the APIs which just happens to live in the "management" API namespace, and that this change will continue to work with the upcoming NSX 5.0 which is removing certain parts of the Management API.

## Related PR and Issues
N/A

## Impacted Areas in Application
NSX tagging, CPI configuration, additional work in the `set_vm_metadata` call.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Manual testing against a live 4.x NSX-T
- [X] Automated testing against NSX 3.0 with the integration tests included 

**Test Configuration**:
* Tests run were configured in the environments in the Concourse Jobs set up by the `ci/configure.sh` script.

# Checklist:

- [ ] My code follows the standard ruby style guide
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
