### PR TITLE
New VM type cloud property for CPU reservation

### DIFF
--- a/jobs/vsphere_cpi/spec
+++ b/jobs/vsphere_cpi/spec
@@ -26,6 +26,9 @@ properties:
   vcenter.enable_auto_anti_affinity_drs_rules:
     description: Creates anti-affinity DRS rules for each instance group of each bosh deployment to place VMs on separate hosts. The DRS rules are named from template <bosh-director-name>-<bosh-deployment-name>-<instance-group-name>
     default: false
+  vcenter.cpu_reserve_full_mhz:
+    description: When enabled, the CPI will reserve CPU equal to the largest ESXi host in the host group or cluster the VM is placed in.
+    default: false
   vcenter.memory_reservation_locked_to_max:
     description: When enabled, the requested memory for the VMs will be reserved in vCenter. Enabling this will likely lead to wasted memory on the hosts and will prevent vCenter from making the best use of the memory resources.
     default: false

--- a/jobs/vsphere_cpi/templates/cpi.json.erb
+++ b/jobs/vsphere_cpi/templates/cpi.json.erb
@@ -22,6 +22,7 @@
             "datacenters" => [],
             "default_disk_type" => p('vcenter.default_disk_type'),
             "enable_auto_anti_affinity_drs_rules" => p('vcenter.enable_auto_anti_affinity_drs_rules'),
+            "cpu_reserve_full_mhz" => p('vcenter.cpu_reserve_full_mhz'),
             "memory_reservation_locked_to_max" => p('vcenter.memory_reservation_locked_to_max'),
             "upgrade_hw_version" => p('vcenter.upgrade_hw_version'),
             "enable_human_readable_name" => p('vcenter.enable_human_readable_name'),

--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -331,7 +331,7 @@ module VSphereCloud
             ensure_all: true
           )
           stemcell_size /= 1024 * 1024
-          cloud_properties = {"memory_reservation_locked_to_max" => config.memory_reservation_locked_to_max}.merge(cloud_properties)
+          cloud_properties = {'memory_reservation_locked_to_max' => config.memory_reservation_locked_to_max, 'cpu_reserve_full_mhz' => config.cpu_reserve_full_mhz}.merge(cloud_properties)
 
           vm_type = VmType.new(@datacenter, cloud_properties, @pbm)
           disk_configs, policy_name = disk_configurations(vm_type, existing_disk_cids)

--- a/src/vsphere_cpi/lib/cloud/vsphere/config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/config.rb
@@ -264,6 +264,10 @@ module VSphereCloud
       vcenter['vm_storage_policy_name']
     end
 
+    def cpu_reserve_full_mhz
+      vcenter['cpu_reserve_full_mhz']
+    end
+
     def memory_reservation_locked_to_max
       vcenter['memory_reservation_locked_to_max']
     end
@@ -303,6 +307,7 @@ module VSphereCloud
             optional('http_logging') => bool,
             optional('enable_auto_anti_affinity_drs_rules') => bool,
             optional('upgrade_hw_version') => bool,
+            optional('cpu_reserve_full_mhz') => bool,
             optional('memory_reservation_locked_to_max') => bool,
             optional('vm_storage_policy_name') => String,
             optional('vmx_options') => {

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/cluster.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/cluster.rb
@@ -14,7 +14,7 @@ module VSphereCloud
       CLUSTER_VM_HOST_RULE_SHOULD = 'SHOULD'.freeze
       CLUSTER_VM_HOST_RULE_MUST = 'MUST'.freeze
       PROPERTIES = %w(name datastore resourcePool host)
-      HOST_PROPERTIES = %w(name hardware.memorySize runtime.connectionState runtime.inMaintenanceMode runtime.powerState)
+      HOST_PROPERTIES = %w(name hardware.memorySize runtime.connectionState runtime.inMaintenanceMode runtime.powerState summary.hardware.cpuMhz)
       HOST_COUNTERS = %w(mem.usage.average)
 
       MEMORY_HEADROOM = 128

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
@@ -135,6 +135,7 @@ module VSphereCloud
       params[:num_cpus] = vm_type.cpu
       params[:memory_mb] = vm_type.ram
       params[:memory_reservation_locked_to_max] = true if memory_reservation_locked_to_max?
+      params[:cpu_allocation] = VimSdk::Vim::ResourceAllocationInfo.new(reservation:  vm_type.cpu_reservation_mhz) if !vm_type.cpu_reservation_mhz.nil?
       params[:nested_hv_enabled] = true if vm_type.nested_hardware_virtualization
       params[:cpu_hot_add_enabled] = true if vm_type.cpu_hot_add_enabled
       params[:memory_hot_add_enabled] = true if vm_type.memory_hot_add_enabled

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
@@ -40,6 +40,7 @@ module VSphereCloud
         cluster = cluster_placement.cluster
         # Validates if the rule specified is of right syntax
         vm_config.validate_drs_rules(cluster)
+        vm_config.calculate_cpu_reservation(cluster)
 
         # @TA: TODO Choose host here if needed.
         ordered_ephemeral_ds_options = [cluster_placement.disk_placement]

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_type.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_type.rb
@@ -17,7 +17,7 @@ module VSphereCloud
     CLOUD_PROPERTIES_HASH_PROXY_METHODS = %w[
       cpu
       cpu_hot_add_enabled
-      cpu_reservation_mhz
+      cpu_reserve_full_mhz
       datacenters
       disable_drs
       disk

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_type.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_type.rb
@@ -17,6 +17,7 @@ module VSphereCloud
     CLOUD_PROPERTIES_HASH_PROXY_METHODS = %w[
       cpu
       cpu_hot_add_enabled
+      cpu_reservation_mhz
       datacenters
       disable_drs
       disk

--- a/src/vsphere_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/vsphere_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -90,6 +90,7 @@ describe 'cpi.json.erb' do
               'default_disk_type' => 'preallocated',
               'enable_auto_anti_affinity_drs_rules' => true,
               'enable_human_readable_name' => true,
+              'cpu_reserve_full_mhz' => false,
               'memory_reservation_locked_to_max' => false,
               'upgrade_hw_version' => true,
               'http_logging' => true,

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/config_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/config_spec.rb
@@ -40,6 +40,7 @@ module VSphereCloud
     let(:nsx_user) { 'fake-nsx-user' }
     let(:nsx_password) { 'fake-nsx-password' }
     let(:vm_storage_policy_name)  { 'VM Storage Policy' }
+    let(:cpu_reserve_full_mhz)  { true }
     let(:memory_reservation_locked_to_max)  { true }
     before do
       allow(VimSdk::Vim::ServiceInstance).to receive(:new).
@@ -55,6 +56,7 @@ module VSphereCloud
           'password' => password,
           'default_disk_type' => default_disk_type,
           'vm_storage_policy_name' => vm_storage_policy_name,
+          'cpu_reserve_full_mhz' => cpu_reserve_full_mhz,
           'memory_reservation_locked_to_max' => memory_reservation_locked_to_max,
           'enable_human_readable_name' => false,
           'ensure_no_ip_conflicts' => true,
@@ -733,6 +735,12 @@ module VSphereCloud
     describe '#vm_storage_policy_name' do
       it 'returns value from config' do
         expect(config.vm_storage_policy_name).to eq(vm_storage_policy_name)
+      end
+    end
+
+    describe '#cpu_reserve_full_mhz' do
+      it 'returns value from config' do
+        expect(config.cpu_reserve_full_mhz).to eq(cpu_reserve_full_mhz)
       end
     end
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_creator_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_creator_spec.rb
@@ -174,7 +174,7 @@ module VSphereCloud
                                       ephemeral_disk_size: 1024,
                                       pci_passthroughs: [],
                                       vgpus: [],
-
+                                      calculate_cpu_reservation: nil,
                                       cluster_placements: [
                                         instance_double(VmPlacement,
                                                         cluster: cluster,
@@ -269,7 +269,7 @@ module VSphereCloud
                                           ephemeral_disk_size: 1024,
                                           pci_passthroughs: [],
                                           vgpus: [],
-
+                                          calculate_cpu_reservation: nil,
                                           cluster_placements: [
                                             instance_double(VmPlacement,
                                                             cluster: cluster,


### PR DESCRIPTION
Rebase on original PR failed: https://github.com/cloudfoundry/bosh-vsphere-cpi-release/pull/281 so opening new PR here.