### PR TITLE
Handle non-JSON responses from NSX API endpoints

### DIFF
--- a/src/vsphere_cpi/data/swagger-nsxt-manager-template/api_client.mustache
+++ b/src/vsphere_cpi/data/swagger-nsxt-manager-template/api_client.mustache
@@ -56,8 +56,14 @@ module {{moduleName}}
           fail ApiCallError.new(:code => 0,
                             :message => response.return_message)
         else
-          api_error = ApiError.new(JSON.parse(response.body))
-          error_message = api_error.related_errors ? api_error.related_errors : api_error.error_message
+          error_message = ''
+          begin
+            api_error = ApiError.new(JSON.parse(response.body))
+            error_message = api_error.related_errors ? api_error.related_errors : api_error.error_message
+          rescue JSON::ParserError
+            error_message = "Unable to parse JSON response.\nReturn code:#{response.return_code}\nReturn message:#{response.return_message}\nResponse body: #{response.body}"
+          end
+
           fail ApiCallError.new(:code => response.code,
                             :response_headers => response.headers,
                             :response_body => response.body,

--- a/src/vsphere_cpi/data/swagger-nsxt-policy-template/api_client.mustache
+++ b/src/vsphere_cpi/data/swagger-nsxt-policy-template/api_client.mustache
@@ -56,8 +56,14 @@ module {{moduleName}}
           fail ApiCallError.new(:code => 0,
                             :message => response.return_message)
         else
-          api_error = ApiError.new(JSON.parse(response.body))
-          error_message = api_error.related_errors ? api_error.related_errors : api_error.error_message
+          error_message = ''
+          begin
+            api_error = ApiError.new(JSON.parse(response.body))
+            error_message = api_error.related_errors ? api_error.related_errors : api_error.error_message
+          rescue JSON::ParserError
+            error_message = "Unable to parse JSON response.\nReturn code:#{response.return_code}\nReturn message:#{response.return_message}\nResponse body: #{response.body}"
+          end
+
           fail ApiCallError.new(:code => response.code,
                             :response_headers => response.headers,
                             :response_body => response.body,

--- a/src/vsphere_cpi/lib/nsxt_manager_client/nsxt_manager_client/api_client.rb
+++ b/src/vsphere_cpi/lib/nsxt_manager_client/nsxt_manager_client/api_client.rb
@@ -64,8 +64,14 @@ module NSXT
           fail ApiCallError.new(:code => 0,
                             :message => response.return_message)
         else
-          api_error = ApiError.new(JSON.parse(response.body))
-          error_message = api_error.related_errors ? api_error.related_errors : api_error.error_message
+          error_message = ''
+          begin
+            api_error = ApiError.new(JSON.parse(response.body))
+            error_message = api_error.related_errors ? api_error.related_errors : api_error.error_message
+          rescue JSON::ParserError
+            error_message = "Unable to parse JSON response.\nReturn code:#{response.return_code}\nReturn message:#{response.return_message}\nResponse body: #{response.body}"
+          end
+
           fail ApiCallError.new(:code => response.code,
                             :response_headers => response.headers,
                             :response_body => response.body,

--- a/src/vsphere_cpi/lib/nsxt_policy_client/nsxt_policy_client/api_client.rb
+++ b/src/vsphere_cpi/lib/nsxt_policy_client/nsxt_policy_client/api_client.rb
@@ -64,8 +64,14 @@ module NSXTPolicy
           fail ApiCallError.new(:code => 0,
                             :message => response.return_message)
         else
-          api_error = ApiError.new(JSON.parse(response.body))
-          error_message = api_error.related_errors ? api_error.related_errors : api_error.error_message
+          error_message = ''
+          begin
+            api_error = ApiError.new(JSON.parse(response.body))
+            error_message = api_error.related_errors ? api_error.related_errors : api_error.error_message
+          rescue JSON::ParserError
+            error_message = "Unable to parse JSON response.\nReturn code:#{response.return_code}\nReturn message:#{response.return_message}\nResponse body: #{response.body}"
+          end
+
           fail ApiCallError.new(:code => response.code,
                             :response_headers => response.headers,
                             :response_body => response.body,

--- a/src/vsphere_cpi/spec/unit/cloud/apiclient/api_client_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/apiclient/api_client_spec.rb
@@ -53,6 +53,14 @@ describe 'NSXT' do
       client = NSXT::ApiClient.new
       expect { client.call_api('PUT', 'api/v0/throttled_endpoint') }.to raise_error(NSXT::ApiCallError)
     end
+
+    it 'handles non-JSON responses' do
+      typh_response = instance_double(Typhoeus::Response, success?: false, timed_out?: false, code: 500, body: '', headers: ['some-header'], status_message: 'Server error', return_code: :ok, return_message: 'Some libcurl message')
+      allow_any_instance_of(Typhoeus::Request).to receive(:run).and_return(typh_response)
+
+      client = NSXT::ApiClient.new
+      expect { client.call_api('PUT', 'api/v0/throttled_endpoint') }.to raise_error(NSXT::ApiCallError)
+    end
   end
 end
 
@@ -83,6 +91,14 @@ describe 'NSXTPolicy' do
       typh_response = double('Typhoeus::Response', :success? => false, :timed_out? => false, :code => 429, :body => '{}', :headers => ['some-header'], :status_message => 'Too many requests')
       allow_any_instance_of(Typhoeus::Request).to receive(:run).and_return(typh_response)
       allow_any_instance_of(Kernel).to receive(:sleep) # I don't want the test to take 12 seconds
+      client = NSXTPolicy::ApiClient.new
+      expect { client.call_api('PUT', 'api/v0/throttled_endpoint') }.to raise_error(NSXTPolicy::ApiCallError)
+    end
+
+    it 'handles non-JSON responses' do
+      typh_response = instance_double(Typhoeus::Response, success?: false, timed_out?: false, code: 500, body: '', headers: ['some-header'], status_message: 'Server error', return_code: :ok, return_message: 'Some libcurl message')
+      allow_any_instance_of(Typhoeus::Request).to receive(:run).and_return(typh_response)
+
       client = NSXTPolicy::ApiClient.new
       expect { client.call_api('PUT', 'api/v0/throttled_endpoint') }.to raise_error(NSXTPolicy::ApiCallError)
     end


### PR DESCRIPTION
Previously, if an NSX API endpoint returned a non-successful status code with a non-JSON response, the CPI would raise a parse error that was hard to decypher. Now, it will raise the expected error class with information about the error, include the body and status code, like other API errors.