### PR TITLE
`create_disk` accepts a disk name in cloud properties

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -797,8 +797,9 @@ module VSphereCloud
         pipeline.each do |storage_placement|
           datastore = storage_placement
 
-          logger.info("Trying to create persistent disk on datastore: #{datastore.name}")
-          disk = @datacenter.create_disk(datastore, size_in_mb, disk_type)
+          disk_cid = cloud_properties.key?('name') ? cloud_properties['name'] : "disk-#{SecureRandom.uuid}"
+          logger.info("Trying to create persistent disk #{disk_cid} on datastore: #{datastore.name}")
+          disk = @datacenter.create_disk(disk_cid, datastore, size_in_mb, disk_type)
           next if disk.nil?
 
           logger.info("Created disk: #{disk.inspect}")

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/datacenter.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/datacenter.rb
@@ -93,14 +93,12 @@ module VSphereCloud
         end
       end
 
-      def create_disk(datastore, size_in_mb, disk_type)
+      def create_disk(disk_cid, datastore, size_in_mb, disk_type)
         unless Resources::PersistentDisk::SUPPORTED_DISK_TYPES.include?(disk_type)
           raise "Disk type: '#{disk_type}' is not supported"
         end
 
-        disk_cid = "disk-#{SecureRandom.uuid}"
         logger.debug("Creating disk '#{disk_cid}' in datastore '#{datastore.name}'")
-
         @client.create_disk(mob, datastore, disk_cid, @disk_path, size_in_mb, disk_type)
       end
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -2490,6 +2490,7 @@ module VSphereCloud
           folder: 'fake-folder',
         )
       end
+      let(:disk_with_uuid_regex) { /\Adisk-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/ }
 
       before do
         allow(small_ds).to receive(:accessible?).and_return(accessible)
@@ -2502,18 +2503,29 @@ module VSphereCloud
 
       it 'creates disk via datacenter' do
         expect(datacenter).to receive(:create_disk)
-          .with(VSphereCloud::Resources::Datastore, 1024, default_disk_type)
+          .with(a_string_matching(disk_with_uuid_regex), VSphereCloud::Resources::Datastore, 1024, default_disk_type)
           .and_return(disk)
 
         disk_cid = vsphere_cloud.create_disk(1024, {})
         expect(disk_cid).to eq('fake-disk-cid')
       end
 
+      context 'when disk name is passed in cloud properties' do
+        it 'uses provided disk name' do
+          expect(datacenter).to receive(:create_disk)
+                                  .with('some-disk-name', VSphereCloud::Resources::Datastore, 1024, default_disk_type)
+                                  .and_return(disk)
+
+          disk_cid = vsphere_cloud.create_disk(1024, {'name' => 'some-disk-name'})
+          expect(disk_cid).to eq(disk.cid)
+        end
+      end
+
       context 'when global default_disk_type is set and no disk_pool type is set' do
         let(:default_disk_type) { 'fake-global-type' }
         it 'creates disk with the specified default type' do
           expect(datacenter).to receive(:create_disk)
-                                  .with(VSphereCloud::Resources::Datastore, 1024, 'fake-global-type')
+                                  .with(a_string_matching(disk_with_uuid_regex), VSphereCloud::Resources::Datastore, 1024, 'fake-global-type')
                                   .and_return(disk)
 
           disk_cid = vsphere_cloud.create_disk(1024, {})
@@ -2574,7 +2586,7 @@ module VSphereCloud
         let(:default_disk_type) { 'fake-global-type' }
         it 'create disk with the specified disk_pool type' do
           expect(datacenter).to receive(:create_disk)
-                                  .with(VSphereCloud::Resources::Datastore, 1024, 'fake-disk-pool-type')
+                                  .with(a_string_matching(disk_with_uuid_regex), VSphereCloud::Resources::Datastore, 1024, 'fake-disk-pool-type')
                                   .and_return(disk)
           disk_cid = vsphere_cloud.create_disk(1024, {'type' => 'fake-disk-pool-type'})
           expect(disk_cid).to eq('fake-disk-cid')
@@ -2584,7 +2596,7 @@ module VSphereCloud
       context 'when no global default_disk_type is set and disk_pool type is set' do
         it 'creates disk with the specified disk_pool type' do
           expect(datacenter).to receive(:create_disk)
-            .with(VSphereCloud::Resources::Datastore, 1024, 'fake-disk-pool-type')
+            .with(a_string_matching(disk_with_uuid_regex), VSphereCloud::Resources::Datastore, 1024, 'fake-disk-pool-type')
             .and_return(disk)
 
           disk_cid = vsphere_cloud.create_disk(1024, {'type' => 'fake-disk-pool-type'})
@@ -2610,7 +2622,7 @@ module VSphereCloud
 
         it 'creates disk in vm cluster' do
           expect(datacenter).to receive(:create_disk)
-            .with(datastore, 1024, default_disk_type)
+            .with(a_string_matching(disk_with_uuid_regex), datastore, 1024, default_disk_type)
             .and_return(disk)
 
           disk_cid = vsphere_cloud.create_disk(1024, {}, 'fake-vm-cid')
@@ -2631,10 +2643,10 @@ module VSphereCloud
             .with('large-ds')
             .and_return(large_datastore)
           allow(datacenter).to receive(:create_disk)
-            .with(VSphereCloud::Resources::Datastore, 1024, default_disk_type)
+            .with(a_string_matching(disk_with_uuid_regex), VSphereCloud::Resources::Datastore, 1024, default_disk_type)
             .and_return(disk)
           allow(datacenter).to receive(:create_disk)
-            .with(VSphereCloud::Resources::Datastore, 1024, default_disk_type)
+            .with(a_string_matching(disk_with_uuid_regex), VSphereCloud::Resources::Datastore, 1024, default_disk_type)
             .and_return(disk)
         end
 

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/datacenter_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/datacenter_spec.rb
@@ -333,14 +333,13 @@ describe VSphereCloud::Resources::Datacenter, fake_logger: true do
     let(:virtual_disk_manager) { instance_double('VimSdk::Vim::VirtualDiskManager') }
 
     before do
-      allow(SecureRandom).to receive(:uuid).and_return('cid')
       allow(virtual_disk_manager).to receive(:create_virtual_disk)
     end
 
     context 'when disk type is invalid' do
       it 'raises an error' do
         expect {
-          datacenter.create_disk(datastore, 24, 'invalid-type')
+          datacenter.create_disk('disk-cid', datastore, 24, 'invalid-type')
         }.to raise_error("Disk type: 'invalid-type' is not supported")
       end
     end
@@ -351,7 +350,7 @@ describe VSphereCloud::Resources::Datacenter, fake_logger: true do
                             .with(datacenter_mob, datastore, 'disk-cid', 'fake-disk-path', 24, 'thin')
                             .and_return(disk)
 
-        expect(datacenter.create_disk(datastore, 24, 'thin')).to eq(disk)
+        expect(datacenter.create_disk('disk-cid', datastore, 24, 'thin')).to eq(disk)
       end
     end
   end


### PR DESCRIPTION
# Description

If 'name' is provided in cloud properties in create_disk call vsphere CPI will create disk with that name. Otherwise, it will use the generated name.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Call cpi binary on BOSH Director VM with create_disk method and json:

```
{
  "method": "create_disk",
  "arguments": [10240, {"name": "mydisk"}, nil] 
}
```

Check vSphere that the disk with the specified name is created.

# Checklist:

- [X] My code follows the standard ruby style guide
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
