### PR TITLE
Allow up to 63 disks to be attached to VM

### DIFF
--- a/jobs/vsphere_cpi/spec
+++ b/jobs/vsphere_cpi/spec
@@ -33,8 +33,11 @@ properties:
     description: When enabled, the requested memory for the VMs will be reserved in vCenter. Enabling this will likely lead to wasted memory on the hosts and will prevent vCenter from making the best use of the memory resources.
     default: false
   vcenter.upgrade_hw_version:
-    description: Upgrades virtual machines to latest virtual hardware version supported on the ESXi host.
+    description: Upgrades virtual machines to latest virtual hardware version supported on the ESXi host. This overrides default_hw_version.
     default: false
+  vcenter.default_hw_version:
+    description: Upgrades virtual machines to the specified virtual hardware version.
+    default: 17
   vcenter.vm_storage_policy_name:
     description: Name of the storage Policy which is applied to a VM and its ephemeral disk.
   vcenter.enable_human_readable_name:

--- a/jobs/vsphere_cpi/templates/cpi.json.erb
+++ b/jobs/vsphere_cpi/templates/cpi.json.erb
@@ -25,6 +25,7 @@
             "cpu_reserve_full_mhz" => p('vcenter.cpu_reserve_full_mhz'),
             "memory_reservation_locked_to_max" => p('vcenter.memory_reservation_locked_to_max'),
             "upgrade_hw_version" => p('vcenter.upgrade_hw_version'),
+            "default_hw_version" => p('vcenter.default_hw_version'),
             "enable_human_readable_name" => p('vcenter.enable_human_readable_name'),
             "http_logging" => p('vcenter.http_logging'),
             "ensure_no_ip_conflicts" => p('vcenter.ensure_no_ip_conflicts'),

--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -393,6 +393,7 @@ module VSphereCloud
             enable_auto_anti_affinity_drs_rules: @config.vcenter_enable_auto_anti_affinity_drs_rules,
             stemcell: Stemcell.new(stemcell_cid),
             upgrade_hw_version: @config.upgrade_hw_version,
+            default_hw_version: @config.default_hw_version,
             pbm: @pbm,
           )
           created_vm = vm_creator.create(vm_config)

--- a/src/vsphere_cpi/lib/cloud/vsphere/config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/config.rb
@@ -234,6 +234,10 @@ module VSphereCloud
       vcenter['upgrade_hw_version']
     end
 
+    def default_hw_version
+      vcenter['default_hw_version']
+    end
+
     def nsxt
       return nil unless nsxt_enabled?
       NSXTConfig.new(
@@ -311,6 +315,7 @@ module VSphereCloud
             optional('http_logging') => bool,
             optional('enable_auto_anti_affinity_drs_rules') => bool,
             optional('upgrade_hw_version') => bool,
+            optional('default_hw_version') => Integer,
             optional('cpu_reserve_full_mhz') => bool,
             optional('memory_reservation_locked_to_max') => bool,
             optional('vm_storage_policy_name') => String,

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
@@ -134,6 +134,7 @@ module VSphereCloud
       end
 
       def fix_device_unit_numbers(device_changes)
+        # TODO: remove device number 7, increase to 64
         controllers_available_unit_numbers = Hash.new { |h, k| h[k] = (0..15).to_a }
         devices.each do |device|
           if device.controller_key
@@ -223,8 +224,9 @@ module VSphereCloud
         @client.power_on_vm(datacenter_mob, @mob)
       end
 
-      def upgrade_vm_virtual_hardware
-        @client.upgrade_vm_virtual_hardware(@mob)
+      def upgrade_vm_virtual_hardware(version = nil)
+        version_name = version.nil? ? nil : "vmx-#{version}"
+        @client.upgrade_vm_virtual_hardware(@mob, version_name)
       end
 
       def delete

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
@@ -392,6 +392,24 @@ module VSphereCloud
         profile_spec
       end
 
+      def create_paravirtual_scsi_controller_spec
+        scsi_controller = devices.find { |device| device.kind_of?(Vim::Vm::Device::VirtualSCSIController) }
+        return nil if scsi_controller.nil?
+
+        new_scsi_controller = VimSdk::Vim::Vm::Device::ParaVirtualSCSIController.new
+        new_scsi_controller.key = scsi_controller.key
+        new_scsi_controller.slot_info = scsi_controller.slot_info
+        new_scsi_controller.controller_key = scsi_controller.controller_key
+        new_scsi_controller.unit_number = scsi_controller.unit_number
+        new_scsi_controller.bus_number = scsi_controller.bus_number
+        new_scsi_controller.device = scsi_controller.device
+        new_scsi_controller.scsi_ctlr_unit_number = scsi_controller.scsi_ctlr_unit_number
+        new_scsi_controller.shared_bus = scsi_controller.shared_bus
+        new_scsi_controller.hot_add_remove = scsi_controller.hot_add_remove
+
+        new_scsi_controller
+      end
+
       def self.create_delete_device_spec(device, options = {})
         device_config_spec = Vim::Vm::Device::VirtualDeviceSpec.new
         device_config_spec.device = device

--- a/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/resources/vm.rb
@@ -134,8 +134,7 @@ module VSphereCloud
       end
 
       def fix_device_unit_numbers(device_changes)
-        # TODO: remove device number 7, increase to 64
-        controllers_available_unit_numbers = Hash.new { |h, k| h[k] = (0..15).to_a }
+        controllers_available_unit_numbers = Hash.new { |h, k| h[k] = (0..63).grep_v(7) }
         devices.each do |device|
           if device.controller_key
             available_unit_numbers = controllers_available_unit_numbers[device.controller_key]

--- a/src/vsphere_cpi/lib/cloud/vsphere/vcenter_client.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vcenter_client.rb
@@ -79,10 +79,10 @@ module VSphereCloud
       vm.answer(question, answer)
     end
 
-    def upgrade_vm_virtual_hardware(vm)
+    def upgrade_vm_virtual_hardware(vm, version = nil)
       logger.info("Upgrading virtual hardware on VM")
       wait_for_task do
-        vm.upgrade_virtual_hardware
+        vm.upgrade_virtual_hardware(version)
       end
     end
 

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
@@ -86,6 +86,11 @@ module VSphereCloud
           config_spec = VimSdk::Vim::Vm::ConfigSpec.new(vm_config.config_spec_params)
           config_spec.device_change = []
 
+          paravirtual_scsi_controller_spec = replicated_stemcell_vm.create_paravirtual_scsi_controller_spec
+          raise 'Failed to create device change to paravirtual controller' if paravirtual_scsi_controller_spec.nil?
+          scsi_controller_device_change_spec = Resources::VM.create_edit_device_spec(paravirtual_scsi_controller_spec)
+          config_spec.device_change << scsi_controller_device_change_spec
+
           ephemeral_disk = Resources::EphemeralDisk.new(
             size_in_mb: vm_config.ephemeral_disk_size,
             datastore:,

--- a/src/vsphere_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/vsphere_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -93,6 +93,7 @@ describe 'cpi.json.erb' do
               'cpu_reserve_full_mhz' => false,
               'memory_reservation_locked_to_max' => false,
               'upgrade_hw_version' => true,
+              'default_hw_version' => 17,
               'http_logging' => true,
               'ensure_no_ip_conflicts' => true,
               'vm_storage_policy_name' => 'VM Storage Policy'

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -33,6 +33,7 @@ module VSphereCloud
         soap_log: 'fake-log-file',
         vcenter_enable_auto_anti_affinity_drs_rules: false,
         upgrade_hw_version: true,
+        default_hw_version: 17,
         vcenter_http_logging: true,
         nsxt_enabled?: nsxt_enabled,
         nsxt: nsxt,
@@ -631,6 +632,7 @@ module VSphereCloud
             enable_auto_anti_affinity_drs_rules: false,
             stemcell: stemcell,
             upgrade_hw_version: true,
+            default_hw_version: 17,
             pbm: pbm,
           ).and_return(vm_creator)
         expect(vm_creator).to receive(:create).with(vm_config).and_return(fake_vm)
@@ -681,6 +683,7 @@ module VSphereCloud
             default_disk_type: default_disk_type,
             enable_auto_anti_affinity_drs_rules: false,
             upgrade_hw_version: true,
+            default_hw_version: 17,
             stemcell: stemcell,
             pbm: pbm,
         ).and_return(vm_creator)
@@ -851,6 +854,7 @@ module VSphereCloud
                                    default_disk_type: 'thin',
                                    enable_auto_anti_affinity_drs_rules: false,
                                    upgrade_hw_version: true,
+                                   default_hw_version: 17,
                                    stemcell: stemcell,
                                    pbm: pbm,
                                  )
@@ -1720,6 +1724,7 @@ module VSphereCloud
                                    default_disk_type: 'preallocated',
                                    enable_auto_anti_affinity_drs_rules: false,
                                    upgrade_hw_version: true,
+                                   default_hw_version: 17,
                                    stemcell: stemcell,
                                    pbm: pbm,
                                  )
@@ -1784,6 +1789,7 @@ module VSphereCloud
                                    default_disk_type: 'preallocated',
                                    enable_auto_anti_affinity_drs_rules: false,
                                    upgrade_hw_version: true,
+                                   default_hw_version: 17,
                                    stemcell: stemcell,
                                    pbm: pbm,
                                  )

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/vm_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/resources/vm_spec.rb
@@ -615,6 +615,55 @@ describe VSphereCloud::Resources::VM, fake_logger: true do
     end
   end
 
+  describe 'create_paravirtual_scsi_controller_spec' do
+    let(:lsi_scsi_controller) do
+      device = VimSdk::Vim::Vm::Device::VirtualLsiLogicController.new
+      device.key = 7777
+      device.slot_info = double('slot-info')
+      device.controller_key = 1234
+      device.unit_number = 4567
+      device.bus_number = 6789
+      device.device = double('device')
+      device.scsi_ctlr_unit_number = 3456
+      device.shared_bus = 'noSharing'
+      device.hot_add_remove = true
+      device
+    end
+
+    let(:paravirtual_scsi_controller) do
+      device = VimSdk::Vim::Vm::Device::ParaVirtualSCSIController.new
+      device.
+      device.
+      device.controller_key = 1234
+      device.unit_number = 4567
+      device.bus_number = 6789
+      device.device = double('device')
+      device.scsi_ctlr_unit_number = 3456
+      device.shared_bus = 'noSharing'
+      device.hot_add_remove = true
+      device
+    end
+
+    let(:vm_properties) { { 'config.hardware.device' => [lsi_scsi_controller] } }
+
+    it 'creates a new paravirtual scsi controller device spec' do
+      expect(vm.create_paravirtual_scsi_controller_spec).
+        to be_a(
+             VimSdk::Vim::Vm::Device::ParaVirtualSCSIController
+           ).and have_attributes(
+                   key: 7777,
+                   slot_info: lsi_scsi_controller.slot_info,
+                   controller_key: 1234,
+                   unit_number: 4567,
+                   bus_number: 6789,
+                   device: lsi_scsi_controller.device,
+                   scsi_ctlr_unit_number: 3456,
+                   shared_bus: 'noSharing',
+                   hot_add_remove: true
+                 )
+    end
+  end
+
   describe '#to_s' do
     it 'show relevant info' do
       expect(subject.to_s).to eq("(#{subject.class.name} (cid=\"vm-cid\"))")


### PR DESCRIPTION
# Description

Currently, vsphere CPI only allows 6 disks to be attached. To allow up to 63 disks to be attached vsphere CPI needs:
1. bumped hardware version on VM to 17
2. switch from default SCSI controller to Paravirtual SCSI controller
3. skip device with number 7

In the future, this can be enhanced by adding additional SCSI controllers in attach_disk call (up to 4) to allow 252 disks.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Create 64 disks and call CPI attach_disk method 63 times and see that 63 disks are attached.


# Checklist:

- [X] My code follows the standard ruby style guide
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
