### PR TITLE
Modified global cpi config to accept vmx_options like vm_type

### DIFF
--- a/jobs/vsphere_cpi/spec
+++ b/jobs/vsphere_cpi/spec
@@ -80,9 +80,10 @@ properties:
       -----BEGIN CERTIFICATE-----
       MII...
       -----END CERTIFICATE-----
-  vcenter.vmx_options.disk.enableUUID:
-    description: Enable usage of Disk UUIDs for partition lookups of the bosh agent. This is required for Kubernetes Clusters deployed by Bosh to use the Kubernetes CPI (e.g. to provision Pod Volumes). Adds labels to scsi disk devices so the disk device path (`/dev/sd*`) can be discovered via Linux OS. See https://help.ubuntu.com/community/UsingUUID.
-    example: 1 # Allowed values 0 || 1 || "0" || "1"
+  vcenter.vmx_options:
+    description: Inject vmx options globally. For example `disk.enableUUID` to enable usage of Disk UUIDs for partition lookups of the bosh agent.
+    example: {"disk.enableUUID": 1}
+    default: {}
   vcenter.nsxt.default_vif_type:
     description: "Default vif_type for logical port attachment. Supported types: PARENT."
   vcenter.nsxt.use_policy_api:

--- a/jobs/vsphere_cpi/templates/cpi.json.erb
+++ b/jobs/vsphere_cpi/templates/cpi.json.erb
@@ -29,7 +29,8 @@
             "enable_human_readable_name" => p('vcenter.enable_human_readable_name'),
             "http_logging" => p('vcenter.http_logging'),
             "ensure_no_ip_conflicts" => p('vcenter.ensure_no_ip_conflicts'),
-            "connection_options" => p('vcenter.connection_options')
+            "connection_options" => p('vcenter.connection_options'),
+            "vmx_options" => p('vcenter.vmx_options'),
           }
         ],
         "agent" => {
@@ -80,12 +81,6 @@
 
       vcenter["datacenters"] << datacenter_hash
     end
-  end
-
-  if_p('vcenter.vmx_options.disk.enableUUID') do
-    vcenter = params['cloud']['properties']['vcenters'].first
-    vcenter['vmx_options'] = {} if vcenter['vmx_options'].nil?
-    vcenter['vmx_options']['disk'] = p('vcenter.vmx_options.disk')
   end
 
   if_p('vcenter.nsx.address') do

--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -367,7 +367,7 @@ module VSphereCloud
             disk_configurations: disk_configs,
             storage_policy: policy_name,
             enable_human_readable_name: config.human_readable_name_enabled?,
-            enable_disk_uuid: config.disk_uuid_is_enabled?
+            vmx_options: config.vmx_options,
           }
 
           if config.human_readable_name_enabled?

--- a/src/vsphere_cpi/lib/cloud/vsphere/config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/config.rb
@@ -276,11 +276,8 @@ module VSphereCloud
       vcenter['memory_reservation_locked_to_max']
     end
 
-    def disk_uuid_is_enabled?
-      # For backwards compatability we need to check both '1' and 1 as both were previously acceptable due to
-      # inconsistent input validation (the cpi.json file enforces integer typing, but the cpi config does not). So
-      # we need to normalise it out here at the edge of the system.
-      [1, '1'].include? vcenter.dig('vmx_options', 'disk', 'enableUUID')
+    def vmx_options
+      vcenter['vmx_options'] || {}
     end
 
     def plugins
@@ -323,11 +320,7 @@ module VSphereCloud
             optional('cpu_reserve_full_mhz') => bool,
             optional('memory_reservation_locked_to_max') => bool,
             optional('vm_storage_policy_name') => String,
-            optional('vmx_options') => {
-              optional('disk') => {
-                optional('enableUUID') => Integer
-              }
-            },
+            optional('vmx_options') => dict(String, any),
             optional('nsxt') => {
               optional('host') => String,
               optional('username') => String,

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_config.rb
@@ -165,7 +165,10 @@ module VSphereCloud
     end
 
     def vmx_options
-      vm_type.vmx_options || {}
+      global_vmx_options = @manifest_params[:vmx_options] || {}
+      vm_type_vmx_options = vm_type.vmx_options || {}
+
+      global_vmx_options.merge(vm_type_vmx_options)
     end
 
     #VSphereCloud::VmType
@@ -193,7 +196,7 @@ module VSphereCloud
     end
 
     def disk_uuid_is_enabled?
-      @manifest_params['enable_disk_uuid'] || vm_type.disk_uuid_is_enabled?
+      [1, '1', 'TRUE'].include? vmx_options["disk.enableUUID"]
     end
 
     private

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
@@ -157,19 +157,9 @@ module VSphereCloud
 
           raise "Unable to parse vmx options: 'vmx_options' is not a Hash" unless vm_config.vmx_options.is_a?(Hash)
 
-          vm_extra_config = vm_config.vmx_options.keys.map do |key|
+          config_spec.extra_config = vm_config.vmx_options.keys.map do |key|
             VimSdk::Vim::Option::OptionValue.new(key:, value: vm_config.vmx_options[key])
           end
-          # We need to make sure this setting makes to the ExtraConfig so that future `attach_disk` calls use
-          # disk UUIDs correctly even without access to the vm_type.
-          #
-          # It is also used by vSphere to pass the UUID through to the guest os:
-          # https://knowledge.broadcom.com/external/article/321338/enhanced-guest-os-information-for-disks.html
-          if vm_config.disk_uuid_is_enabled? && !vm_config.vmx_options.include?('disk.enableUUID')
-            vm_extra_config << VimSdk::Vim::Option::OptionValue.new(key: 'disk.enableUUID', value: '1')
-          end
-          config_spec.extra_config = vm_extra_config
-
 
           host = nil
           # Before cloning we need to make sure the host is correctly picked up

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_type.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_type.rb
@@ -69,12 +69,5 @@ module VSphereCloud
     def storage_policy_datastores(policy_name)
       policy_name ? @pbm.find_compatible_datastores(policy_name, @datacenter) : []
     end
-
-    def disk_uuid_is_enabled?
-      # Because of the vSphere vmx option disk.enableUUID the option here is a little different:
-      # `{"disk.enableUUID": 1}` as a key instead of `{"disk": {"enableUUID: 1}}` See `vm.disk_uuid_is_enabled?`
-      # for an explanation of the parameters.
-      [1, '1', 'TRUE'].include? vmx_options&.dig('disk.enableUUID')
-    end
   end
 end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -40,7 +40,7 @@ module VSphereCloud
         agent: additional_agent_env,
         vm_storage_policy_name: global_storage_policy,
         human_readable_name_enabled?: true,
-        disk_uuid_is_enabled?: false
+        vmx_options: vmx_options
       ).as_null_object
     end
     let(:custom_fields_manager) { instance_double('VimSdk::Vim::CustomFieldsManager') }
@@ -78,6 +78,7 @@ module VSphereCloud
     let(:tagging_tagger) { instance_double(TaggingTag::AttachTagToVm) }
     let(:cpi_metadata_version){1}
     let(:additional_agent_env) { {'something' => 'else'} }
+    let(:vmx_options) { { } }
 
     before do |example|
       allow(Config).to receive(:build).with(config).and_return(cloud_config)
@@ -423,7 +424,7 @@ module VSphereCloud
           storage_policy: nil,
           human_readable_name_info: nil,
           enable_human_readable_name: true,
-          enable_disk_uuid: false,
+          vmx_options: {},
         }
 
         expect(VmConfig).to receive(:new)
@@ -477,7 +478,7 @@ module VSphereCloud
           storage_policy: nil,
           human_readable_name_info: nil,
           enable_human_readable_name: true,
-          enable_disk_uuid: false,
+          vmx_options: {},
         }
         expect(VmConfig).to receive(:new)
           .with(
@@ -649,7 +650,7 @@ module VSphereCloud
             storage_policy: nil,
             human_readable_name_info: nil,
             enable_human_readable_name: true,
-            enable_disk_uuid: false,
+            vmx_options: {},
           }
 
           allow(VmConfig).to receive(:new)

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/config_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/config_spec.rb
@@ -822,32 +822,18 @@ module VSphereCloud
       end
     end
 
-    context '#disk_uuid_is_enabled?' do
-      context 'enabled with 1' do
-        let(:vmx_options) { {'disk' => { 'enableUUID' => 1 }} }
-        it 'returns true' do
-          expect(config.disk_uuid_is_enabled?).to eq(true)
+    context '#vmx_options' do
+      context 'is nil' do
+        let(:vmx_options) { nil }
+        it 'returns a default value' do
+          expect(config.vmx_options).to eq({})
         end
       end
 
-      context 'enabled with `1`' do
-        let(:vmx_options) { {'disk' => { 'enableUUID' => '1' }} }
-        it 'returns true' do
-          expect(config.disk_uuid_is_enabled?).to eq(true)
-        end
-      end
-
-      context 'an invalid value' do
-        let(:vmx_options) { { 'disk.enableUUID' => 0 } }
-        it 'returns true' do
-          expect(config.disk_uuid_is_enabled?).to eq(false)
-        end
-      end
-
-      context 'no value' do
-        let(:vmx_options) {}
-        it 'returns true' do
-          expect(config.disk_uuid_is_enabled?).to eq(false)
+      context 'is present' do
+        let(:vmx_options) { { 'abc' => 123 } }
+        it 'returns those options' do
+          expect(config.vmx_options).to eq({'abc' => 123})
         end
       end
     end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_type_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_type_spec.rb
@@ -88,41 +88,5 @@ module VSphereCloud
         end
       end
     end
-
-    describe '#disk_uuid_is_enabled?' do
-      context 'enabled with 1' do
-        let(:vmx_options) { { 'disk.enableUUID' => 1 } }
-        it 'returns true' do
-          expect(vm_type.disk_uuid_is_enabled?).to eq(true)
-        end
-      end
-
-      context 'enabled with `1`' do
-        let(:vmx_options) { { 'disk.enableUUID' => '1' } }
-        it 'returns true' do
-          expect(vm_type.disk_uuid_is_enabled?).to eq(true)
-        end
-      end
-      context 'enabled with TRUE' do
-        let(:vmx_options) { { 'disk.enableUUID' => 'TRUE' } }
-        it 'returns true' do
-          expect(vm_type.disk_uuid_is_enabled?).to eq(true)
-        end
-      end
-
-      context 'an invalid value' do
-        let(:vmx_options) { { 'disk.enableUUID' => 0 } }
-        it 'returns true' do
-          expect(vm_type.disk_uuid_is_enabled?).to eq(false)
-        end
-      end
-
-      context 'no value' do
-        let(:vmx_options) {}
-        it 'returns true' do
-          expect(vm_type.disk_uuid_is_enabled?).to eq(false)
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
# Description

Technically this is breaking but in practice this feature has literally never worked so is it really breaking? Does a tree make a sound if theres no one around? No.

This should simplify the code paths so disk.enableUUID works the same no matter if its specified locally or globally.

## Related PR and Issues
Fixes #393

## Impacted Areas in Application

* Config 
* VM Creation

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit Tests
- [ ] Manual Tests on a running env

# Checklist:

- [x] My code follows the standard ruby style guide
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
