### PR TITLE
Fix incorrect error message on invalid vmx options

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -379,7 +379,7 @@ module VSphereCloud
             cluster_provider: @cluster_provider
           )
 
-          #TODO refactor this so that manifest related params are moved to manifest_params hash
+          # TODO refactor this so that manifest related params are moved to manifest_params hash
           # eg. upgrade_hw_version, default_disk_type, anti_affinity_drs_rules
           vm_creator = VmCreator.new(
             client: @client,
@@ -1017,10 +1017,10 @@ module VSphereCloud
       vm.accessible_datastores[cdrom.backing.datastore.name]
     end
 
-    def verify_props(type, required_properties, properties)
+    def verify_props(cloud_properties_type, required_properties, properties)
       for prop in required_properties
         if properties[prop].nil?
-          raise "Must specify '#{prop}' in #{type} cloud properties."
+          raise "Must specify '#{prop}' in #{cloud_properties_type} cloud properties."
         end
       end
     end

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_creator.rb
@@ -155,8 +155,6 @@ module VSphereCloud
           #   for the new device to be added (for example, by using unique negative integers as temporary keys).
           replicated_stemcell_vm.fix_device_key(config_spec.device_change)
 
-          raise "Unable to parse vmx options: 'vmx_options' is not a Hash" unless vm_config.vmx_options.is_a?(Hash)
-
           config_spec.extra_config = vm_config.vmx_options.keys.map do |key|
             VimSdk::Vim::Option::OptionValue.new(key:, value: vm_config.vmx_options[key])
           end

--- a/src/vsphere_cpi/lib/cloud/vsphere/vm_type.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/vm_type.rb
@@ -12,6 +12,8 @@ module VSphereCloud
       @datacenter = datacenter
       @cloud_properties = cloud_properties
       @pbm = pbm
+
+      validate
     end
 
     CLOUD_PROPERTIES_HASH_PROXY_METHODS = %w[
@@ -68,6 +70,12 @@ module VSphereCloud
     # Datastores compatible with given storage policy
     def storage_policy_datastores(policy_name)
       policy_name ? @pbm.find_compatible_datastores(policy_name, @datacenter) : []
+    end
+
+    private
+
+    def validate
+      raise "Unable to parse vmx options: 'vmx_options' is not a Hash" unless vmx_options.nil? || vmx_options.is_a?(Hash)
     end
   end
 end

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_type_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/vm_type_spec.rb
@@ -88,5 +88,31 @@ module VSphereCloud
         end
       end
     end
+
+    describe '#vmx_options' do
+      context 'with a nil vmx properties' do
+        let(:vmx_options) { nil }
+
+        it 'returns nil' do
+          expect(vm_type.vmx_options).to eq(nil)
+        end
+      end
+
+      context 'with a vmx properties object' do
+        let(:vmx_options) { { 'abc' => 123 } }
+
+        it 'returns the properties' do
+          expect(vm_type.vmx_options).to eq(vmx_options)
+        end
+      end
+
+      context 'with an invalid type' do
+        let(:vmx_options) { ['abc' => 123] }
+
+        it 'raises an error during initialisation' do
+          expect { vm_type }.to raise_error(/'vmx_options' is not a Hash/)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
# Description

There is a test which broke due recent changes to merge vmx options from the manifest and cloud properties during the validation. This will correctly raise the validation error before that.

[TNZ-54835]

## Related PR and Issues
Fixes #389 

## Impacted Areas in Application

Fix CI

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran unit tests locally and against CI

# Checklist:

- [x] My code follows the standard ruby style guide
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
