### PR TITLE
Delete stemcell should reject blank ids.

### DIFF
--- a/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
+++ b/src/vsphere_cpi/lib/cloud/vsphere/cloud.rb
@@ -301,6 +301,9 @@ module VSphereCloud
     end
 
     def delete_stemcell(stemcell)
+      if stemcell == ''
+        raise ArgumentError, 'stemcell id cannot be blank'
+      end
       @plugin_registry.run_pre_hooks(__method__, self)
       with_thread_name("delete_stemcell(#{stemcell})") do
         Bosh::ThreadPool.new(max_threads: 32, logger: logger).wrap do |pool|

--- a/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
+++ b/src/vsphere_cpi/spec/unit/cloud/vsphere/cloud_spec.rb
@@ -146,6 +146,14 @@ module VSphereCloud
       end
     end
 
+    describe '#delete_stemcell' do
+      it 'errors when the passed id is blank' do
+        expect do
+          vsphere_cloud.delete_stemcell('')
+        end.to raise_error(ArgumentError, /stemcell id cannot be blank/)
+      end
+    end
+
     describe '#has_vm?' do
       context 'the vm is found' do
         it 'returns true' do


### PR DESCRIPTION
# Description

See https://github.com/cloudfoundry/bosh/issues/2625 for the failure case if blank ids are allowed (briefly, if delete_stemcell is invoked with a blank string, the CPI will try to delete all datacenter VMs). 

## Related PR and Issues
https://github.com/cloudfoundry/bosh/issues/2625 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X ] My code follows the standard ruby style guide
- [X] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] I have added tests that prove my fix is effective or that my feature works
- [X ] New and existing unit tests pass locally with my changes
